### PR TITLE
feat(tui): render provider logos next to subscription names (closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,23 @@ agtop --list --agentic-client claude --agentic-client codex
 
 # Non-interactive refresh loop (for headless monitoring). Not valid with --json.
 agtop --list --watch --delay 5
+
+# Write debug logs to a file while running the TUI (the TUI is unaffected)
+agtop --log-file /tmp/agtop.log
 ```
+
+### Provider logos
+
+When the host terminal supports a real graphics protocol (Kitty,
+iTerm2, Sixel), agtop renders small SVG logos from
+[models.dev](https://models.dev) next to the subscription name in the
+session table, dashboard provider list, and info pane. Logos are
+cached to `~/.cache/agtop/logos/` for 7 days.
+
+Terminals without a graphics protocol (alacritty, VSCode terminal,
+gnome-terminal, …) fall back to the standard text-only layout — the
+logo column is omitted entirely so the table looks identical to
+pre-logo builds. No configuration knob is needed.
 
 ### TUI keys
 

--- a/crates/agtop-cli/src/main.rs
+++ b/crates/agtop-cli/src/main.rs
@@ -80,6 +80,12 @@ struct Cli {
     #[arg(short, long)]
     verbose: bool,
 
+    /// Write logs to the given file instead of stderr. Works in TUI mode
+    /// without corrupting the screen. Implies --verbose unless RUST_LOG
+    /// is set (in which case RUST_LOG wins).
+    #[arg(long, value_name = "PATH")]
+    log_file: Option<std::path::PathBuf>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -102,7 +108,7 @@ fn main() -> Result<()> {
 
     // TUI mode = bare `agtop` with no --list / --json / --watch.
     let tui_mode = !cli.json && !cli.list && !cli.watch;
-    init_logging(cli.verbose, tui_mode);
+    init_logging(cli.verbose, tui_mode, cli.log_file.as_deref());
 
     let plan = Plan::parse(&cli.plan)
         .with_context(|| format!("unknown plan '{}'; try retail|max|included", cli.plan))?;
@@ -315,8 +321,34 @@ fn setup_pricing(refresh: bool, disable: bool) {
     }
 }
 
-fn init_logging(verbose: bool, tui_mode: bool) {
+fn init_logging(verbose: bool, tui_mode: bool, log_file: Option<&std::path::Path>) {
     use tracing_subscriber::{fmt, EnvFilter};
+
+    // Explicit --log-file: always honor it (works in TUI mode too because
+    // logs go to a file, not stderr). RUST_LOG still wins over default
+    // filter; --verbose still bumps default level.
+    if let Some(path) = log_file {
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            Ok(file) => {
+                let default = if verbose { "info" } else { "info" };
+                let filter =
+                    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default));
+                let _ = fmt().with_env_filter(filter).with_writer(file).try_init();
+                return;
+            }
+            Err(e) => {
+                // Fall through to stderr / default behavior; warn once if
+                // not in TUI mode (in TUI mode this would corrupt the screen).
+                if !tui_mode {
+                    eprintln!("--log-file: failed to open {}: {e}", path.display());
+                }
+            }
+        }
+    }
 
     // In TUI mode the alternate screen occupies the whole terminal; any
     // log lines written to stderr corrupt the ratatui rendering and make

--- a/crates/agtop-cli/src/tui/app/mod.rs
+++ b/crates/agtop-cli/src/tui/app/mod.rs
@@ -574,7 +574,6 @@ impl App {
         self.logos = LogoMap(logos);
     }
 
-    #[allow(dead_code)]
     pub fn logo(
         &self,
         client: agtop_core::ClientKind,

--- a/crates/agtop-cli/src/tui/app/mod.rs
+++ b/crates/agtop-cli/src/tui/app/mod.rs
@@ -33,9 +33,15 @@ use agtop_core::session::SessionAnalysis;
 use super::column_config::ColumnConfig;
 use agtop_core::quota::ProviderResult;
 
-struct LogoMap(
-    std::collections::HashMap<agtop_core::ClientKind, ratatui_image::protocol::Protocol>,
-);
+/// Pre-rendered logo cells for one provider. The number of cells equals
+/// the logo column width (currently 3). At render time we just `clone`
+/// these cells into the target buffer instead of going through the full
+/// `Image::render` path on every frame, which used to cost ~30 ms per
+/// frame on the Kitty graphics protocol because the placeholder escape
+/// sequence was rebuilt for every visible row on every redraw.
+pub type LogoCells = Vec<ratatui::buffer::Cell>;
+
+struct LogoMap(std::collections::HashMap<agtop_core::ClientKind, LogoCells>);
 
 impl std::fmt::Debug for LogoMap {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -569,16 +575,22 @@ impl App {
 
     pub fn set_logos(
         &mut self,
-        logos: std::collections::HashMap<agtop_core::ClientKind, ratatui_image::protocol::Protocol>,
+        logos: std::collections::HashMap<agtop_core::ClientKind, LogoCells>,
     ) {
         self.logos = LogoMap(logos);
     }
 
-    pub fn logo(
-        &self,
-        client: agtop_core::ClientKind,
-    ) -> Option<&ratatui_image::protocol::Protocol> {
+    pub fn logo(&self, client: agtop_core::ClientKind) -> Option<&LogoCells> {
         self.logos.0.get(&client)
+    }
+
+    /// True when at least one logo is loaded. Callers that need to
+    /// reserve a logo column (session table, info tab) should hide
+    /// that column when this is false — e.g. on terminals without a
+    /// graphics protocol where the logo would otherwise be invisible
+    /// noise.
+    pub fn has_logos(&self) -> bool {
+        !self.logos.0.is_empty()
     }
 
     /// Backward-compat alias used by events.rs until it's updated.

--- a/crates/agtop-cli/src/tui/column_config.rs
+++ b/crates/agtop-cli/src/tui/column_config.rs
@@ -271,23 +271,36 @@ impl ColumnConfig {
         self
     }
 
-    /// Returns ordered list of visible column IDs.
+    /// Returns ordered list of visible column IDs, including the
+    /// `SubscriptionLogo` slot before `Subscription` when both
+    /// `Subscription` is visible and `with_logo` is true.
     ///
-    /// `SubscriptionLogo` is injected immediately before `Subscription` whenever
-    /// Subscription is visible. It is never stored in `self.columns`.
-    pub fn visible(&self) -> Vec<ColumnId> {
+    /// `SubscriptionLogo` is never stored in `self.columns` — it is
+    /// derived from `Subscription` at view time. Pass `with_logo=false`
+    /// when running on a terminal that cannot render an actual image
+    /// in 3 cells (i.e. halfblocks fallback) so the column doesn't
+    /// reserve dead space.
+    pub fn visible_ext(&self, with_logo: bool) -> Vec<ColumnId> {
         let mut result = Vec::new();
         for entry in &self.columns {
             if !entry.visible {
                 continue;
             }
-            // Inject the logo slot immediately before Subscription.
-            if entry.id == ColumnId::Subscription {
+            if with_logo && entry.id == ColumnId::Subscription {
                 result.push(ColumnId::SubscriptionLogo);
             }
             result.push(entry.id);
         }
         result
+    }
+
+    /// Backwards-compatible wrapper that always includes the logo
+    /// column. New call sites should use `visible_ext` and pass the
+    /// runtime "logos available" flag. Currently used only by the
+    /// test suite, where logo availability is irrelevant.
+    #[cfg(test)]
+    pub fn visible(&self) -> Vec<ColumnId> {
+        self.visible_ext(true)
     }
 
     /// Toggle visibility of a column by index into `self.columns`.

--- a/crates/agtop-cli/src/tui/column_config.rs
+++ b/crates/agtop-cli/src/tui/column_config.rs
@@ -17,6 +17,7 @@ pub enum ColumnId {
     #[serde(alias = "provider")]
     Client,
     Subscription,
+    SubscriptionLogo, // internal — never persisted, always derived from Subscription
     Session,
     Started,
     Age,
@@ -70,6 +71,7 @@ impl ColumnId {
         match self {
             ColumnId::Client => "CLIENT",
             ColumnId::Subscription => "SUB",
+            ColumnId::SubscriptionLogo => "", // no header label
             ColumnId::Session => "SESSION",
             ColumnId::Started => "STARTED",
             ColumnId::Age => "AGE",
@@ -96,6 +98,7 @@ impl ColumnId {
         match self {
             ColumnId::Client => "Agentic client (claude/codex/opencode)",
             ColumnId::Subscription => "Billing subscription label",
+            ColumnId::SubscriptionLogo => "Subscription provider logo",
             ColumnId::Session => "Short session ID",
             ColumnId::Started => "Session start timestamp",
             ColumnId::Age => "Time since last activity",
@@ -123,6 +126,7 @@ impl ColumnId {
         match self {
             ColumnId::Client => Some(10),
             ColumnId::Subscription => Some(16),
+            ColumnId::SubscriptionLogo => Some(3),
             ColumnId::Session => Some(12),
             ColumnId::Started => Some(16),
             ColumnId::Age => Some(5),
@@ -150,6 +154,7 @@ impl ColumnId {
         match self {
             ColumnId::Client => Some(SortColumn::Client),
             ColumnId::Subscription => None,
+            ColumnId::SubscriptionLogo => None,
             ColumnId::Session => None,
             ColumnId::Started => Some(SortColumn::Started),
             ColumnId::Age => Some(SortColumn::LastActive),
@@ -267,12 +272,22 @@ impl ColumnConfig {
     }
 
     /// Returns ordered list of visible column IDs.
+    ///
+    /// `SubscriptionLogo` is injected immediately before `Subscription` whenever
+    /// Subscription is visible. It is never stored in `self.columns`.
     pub fn visible(&self) -> Vec<ColumnId> {
-        self.columns
-            .iter()
-            .filter(|e| e.visible)
-            .map(|e| e.id)
-            .collect()
+        let mut result = Vec::new();
+        for entry in &self.columns {
+            if !entry.visible {
+                continue;
+            }
+            // Inject the logo slot immediately before Subscription.
+            if entry.id == ColumnId::Subscription {
+                result.push(ColumnId::SubscriptionLogo);
+            }
+            result.push(entry.id);
+        }
+        result
     }
 
     /// Toggle visibility of a column by index into `self.columns`.
@@ -398,6 +413,70 @@ impl<'de> Deserialize<'de> for ColumnConfig {
             clients,
         }
         .normalize())
+    }
+}
+
+#[cfg(test)]
+mod subscription_logo_tests {
+    use super::*;
+
+    #[test]
+    fn subscription_logo_not_in_config_tab_columns() {
+        // SubscriptionLogo must never appear in the full column list visible
+        // to the config tab (i.e., ColumnId::all() must not include it).
+        assert!(
+            !ColumnId::all().contains(&ColumnId::SubscriptionLogo),
+            "SubscriptionLogo should not appear in ColumnId::all()"
+        );
+    }
+
+    #[test]
+    fn subscription_logo_always_before_subscription_in_visible() {
+        let cfg = ColumnConfig::default();
+        let visible = cfg.visible();
+        let sub_pos = visible
+            .iter()
+            .position(|&c| c == ColumnId::Subscription)
+            .expect("Subscription should be visible by default");
+        assert!(sub_pos > 0, "SubscriptionLogo should precede Subscription");
+        assert_eq!(
+            visible[sub_pos - 1],
+            ColumnId::SubscriptionLogo,
+            "SubscriptionLogo must immediately precede Subscription"
+        );
+    }
+
+    #[test]
+    fn toggling_subscription_also_toggles_logo() {
+        let mut cfg = ColumnConfig::default();
+        // Find Subscription index in internal columns list.
+        let sub_idx = cfg
+            .columns
+            .iter()
+            .position(|e| e.id == ColumnId::Subscription)
+            .expect("Subscription must be in columns");
+        let was_visible = cfg.columns[sub_idx].visible;
+        cfg.toggle(sub_idx);
+        // Subscription itself must have flipped.
+        assert_eq!(
+            cfg.columns[sub_idx].visible, !was_visible,
+            "Subscription visibility should flip"
+        );
+        // After toggle, visible() should no longer include SubscriptionLogo
+        // (because Subscription is now hidden).
+        let new_visible = cfg.visible();
+        assert!(
+            !new_visible.contains(&ColumnId::SubscriptionLogo),
+            "SubscriptionLogo should not be visible when Subscription is hidden"
+        );
+
+        // Toggle back on — logo must reappear.
+        cfg.toggle(sub_idx);
+        let re_visible = cfg.visible();
+        assert!(
+            re_visible.contains(&ColumnId::SubscriptionLogo),
+            "logo reappears when Subscription is re-enabled"
+        );
     }
 }
 

--- a/crates/agtop-cli/src/tui/mod.rs
+++ b/crates/agtop-cli/src/tui/mod.rs
@@ -90,6 +90,9 @@ struct UiLayout {
     /// Left panel of the Dashboard quota pane (provider list).
     /// Used for scroll-wheel and click hit-testing.
     quota_list_area: Rect,
+    /// Rect + ClientKind for each visible session row's SubscriptionLogo cell.
+    /// Used for the post-table logo render pass.
+    logo_rects: Vec<(Rect, agtop_core::ClientKind)>,
 }
 
 /// Run the interactive TUI. Blocks until the user quits or the terminal
@@ -464,7 +467,14 @@ fn render(
     layout.table_area = outer[1];
 
     render_status(frame, outer[0], app);
-    widgets::session_table::render(frame, outer[1], app, table_state, &mut layout.header_cols);
+    widgets::session_table::render(
+        frame,
+        outer[1],
+        app,
+        table_state,
+        &mut layout.header_cols,
+        &mut layout.logo_rects,
+    );
     render_bottom_panel(frame, outer[2], app, layout);
     render_footer(frame, outer[3], app);
 }
@@ -526,7 +536,14 @@ fn render_dashboard(
 
     layout.table_area = outer[3];
     layout.tab_bar_area = Rect::default();
-    widgets::session_table::render(frame, outer[3], app, table_state, &mut layout.header_cols);
+    widgets::session_table::render(
+        frame,
+        outer[3],
+        app,
+        table_state,
+        &mut layout.header_cols,
+        &mut layout.logo_rects,
+    );
     render_footer(frame, outer[4], app);
 }
 

--- a/crates/agtop-cli/src/tui/mod.rs
+++ b/crates/agtop-cli/src/tui/mod.rs
@@ -475,6 +475,7 @@ fn render(
         &mut layout.header_cols,
         &mut layout.logo_rects,
     );
+    render_logo_pass(frame, &layout.logo_rects, app);
     render_bottom_panel(frame, outer[2], app, layout);
     render_footer(frame, outer[3], app);
 }
@@ -544,7 +545,29 @@ fn render_dashboard(
         &mut layout.header_cols,
         &mut layout.logo_rects,
     );
+    render_logo_pass(frame, &layout.logo_rects, app);
     render_footer(frame, outer[4], app);
+}
+
+/// Second-pass logo render: overlays provider logos onto the SubscriptionLogo
+/// column cells after the session table has been drawn.
+fn render_logo_pass(
+    frame: &mut Frame<'_>,
+    logo_rects: &[(Rect, agtop_core::ClientKind)],
+    app: &App,
+) {
+    use ratatui_image::Image;
+
+    for &(rect, client) in logo_rects {
+        if rect.width == 0 || rect.height == 0 {
+            continue;
+        }
+        if let Some(proto) = app.logo(client) {
+            let img = Image::new(proto);
+            frame.render_widget(img, rect);
+        }
+        // When no logo: do nothing — the blank cell is already rendered by the table.
+    }
 }
 
 fn render_status(frame: &mut Frame<'_>, area: Rect, app: &App) {

--- a/crates/agtop-cli/src/tui/mod.rs
+++ b/crates/agtop-cli/src/tui/mod.rs
@@ -149,23 +149,42 @@ pub fn run(
     if !raw_logos.is_empty() {
         let picker = ratatui_image::picker::Picker::from_query_stdio()
             .unwrap_or_else(|_| ratatui_image::picker::Picker::from_fontsize((1, 1)));
-        let mut logos = std::collections::HashMap::new();
-        for (client, svg_bytes) in raw_logos {
-            let img = match decode_svg(&svg_bytes) {
-                Some(img) => img,
-                None => continue,
-            };
-            let proto = match picker.new_protocol(
-                img,
-                ratatui::layout::Rect::new(0, 0, 1, 1),
-                ratatui_image::Resize::Fit(None),
-            ) {
-                Ok(p) => p,
-                Err(_) => continue,
-            };
-            logos.insert(client, proto);
+        // Halfblocks falls back to two-pixels-per-cell colored squares;
+        // a 24×24 logo squashed into LOGO_WIDTH×1 (≈3×2 px) is
+        // unrecognizable noise on terminals without a real graphics
+        // protocol (alacritty, vscode terminal, gnome-terminal, etc.).
+        // Skip logos entirely on those terminals; the table layout below
+        // also drops the logo column when no logos are loaded.
+        let supports_graphics =
+            picker.protocol_type() != ratatui_image::picker::ProtocolType::Halfblocks;
+        if supports_graphics {
+            let mut logos = std::collections::HashMap::new();
+            for (client, svg_bytes) in raw_logos {
+                let img = match decode_svg(&svg_bytes) {
+                    Some(img) => img,
+                    None => continue,
+                };
+                // Render the protocol once into an LOGO_WIDTH×1 scratch
+                // buffer at logo init time and cache the resulting cells.
+                // We then copy these cells directly into the target buffer
+                // on every frame instead of re-running `Image::render`,
+                // which on the Kitty graphics protocol rebuilds a
+                // kilobyte-sized placeholder escape sequence per cell per
+                // frame and was costing ~30 ms per frame across all
+                // visible session rows.
+                let proto = match picker.new_protocol(
+                    img,
+                    ratatui::layout::Rect::new(0, 0, LOGO_WIDTH, 1),
+                    ratatui_image::Resize::Fit(None),
+                ) {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+                let cells = render_logo_to_cells(&proto);
+                logos.insert(client, cells);
+            }
+            app.set_logos(logos);
         }
-        app.set_logos(logos);
     }
 
     let result = event_loop(&mut terminal, &mut app, &mut handle);
@@ -549,22 +568,68 @@ fn render_dashboard(
     render_footer(frame, outer[4], app);
 }
 
+/// Width of a provider-logo cell, in terminal columns. Must match
+/// `ColumnId::SubscriptionLogo::fixed_width` and the logo column
+/// constraints in the dashboard provider list and the info-tab
+/// subscription line.
+pub const LOGO_WIDTH: u16 = 3;
+
+/// Render a `Protocol` into an `LOGO_WIDTH × 1` scratch buffer once and
+/// return the resulting cells. We use these as a stamp at draw time
+/// (see `render_logo_pass` and `paste_logo_cells`) so that we never
+/// re-run the protocol's `render` on every frame. Cells embed any
+/// transmit/escape data the protocol needs to emit; ratatui's diff
+/// suppresses repeats when the cells are stable.
+fn render_logo_to_cells(proto: &ratatui_image::protocol::Protocol) -> Vec<ratatui::buffer::Cell> {
+    use ratatui::widgets::Widget;
+    use ratatui_image::Image;
+
+    let area = Rect::new(0, 0, LOGO_WIDTH, 1);
+    let mut buf = ratatui::buffer::Buffer::empty(area);
+    Image::new(proto).render(area, &mut buf);
+    let mut cells = Vec::with_capacity(LOGO_WIDTH as usize);
+    for x in 0..LOGO_WIDTH {
+        if let Some(cell) = buf.cell((x, 0)) {
+            cells.push(cell.clone());
+        }
+    }
+    cells
+}
+
+/// Stamp pre-rendered logo cells into the target buffer at `rect`.
+/// Used as the cheap inner loop of `render_logo_pass`.
+fn paste_logo_cells(
+    buf: &mut ratatui::buffer::Buffer,
+    rect: Rect,
+    cells: &[ratatui::buffer::Cell],
+) {
+    if rect.height == 0 {
+        return;
+    }
+    let max_x = rect.width.min(cells.len() as u16);
+    for x in 0..max_x {
+        if let Some(target) = buf.cell_mut((rect.x + x, rect.y)) {
+            *target = cells[x as usize].clone();
+        }
+    }
+}
+
 /// Second-pass logo render: overlays provider logos onto the SubscriptionLogo
-/// column cells after the session table has been drawn.
+/// column cells after the session table has been drawn. Uses pre-rendered
+/// cell stamps cached in `App::logos` to avoid rebuilding the per-protocol
+/// escape sequences on every frame.
 fn render_logo_pass(
     frame: &mut Frame<'_>,
     logo_rects: &[(Rect, agtop_core::ClientKind)],
     app: &App,
 ) {
-    use ratatui_image::Image;
-
+    let buf = frame.buffer_mut();
     for &(rect, client) in logo_rects {
         if rect.width == 0 || rect.height == 0 {
             continue;
         }
-        if let Some(proto) = app.logo(client) {
-            let img = Image::new(proto);
-            frame.render_widget(img, rect);
+        if let Some(cells) = app.logo(client) {
+            paste_logo_cells(buf, rect, cells);
         }
         // When no logo: do nothing — the blank cell is already rendered by the table.
     }

--- a/crates/agtop-cli/src/tui/widgets/dashboard_plan.rs
+++ b/crates/agtop-cli/src/tui/widgets/dashboard_plan.rs
@@ -66,13 +66,21 @@ fn render_centered(frame: &mut Frame<'_>, area: Rect, msg: &str) {
 }
 
 fn render_list(frame: &mut Frame<'_>, area: Rect, app: &App) {
-    use crate::tui::widgets::quota_bar::{error_token, provider_short_name, status_glyph};
+    use crate::tui::widgets::quota_bar::{
+        error_token, provider_short_name, status_glyph, status_style,
+    };
+    use agtop_core::logo::provider_id_to_client_kind;
+    use ratatui_image::Image;
 
     let slots = app.quota_slots();
     let selected = app.selected_provider();
 
-    let mut lines: Vec<Line<'_>> = Vec::with_capacity(slots.len());
     for (i, slot) in slots.iter().enumerate() {
+        let row_y = area.y + i as u16;
+        if row_y >= area.y + area.height {
+            break;
+        }
+
         let is_selected = i == selected;
         let stale = !slot.current.ok && slot.last_good.is_some();
         let errored = !slot.current.ok && slot.last_good.is_none();
@@ -103,27 +111,64 @@ fn render_list(frame: &mut Frame<'_>, area: Rect, app: &App) {
             None
         };
 
-        let line_text = format!(
-            "{glyph} {name}{name_suffix}{}",
+        let plan_text = format!(
+            "{name}{name_suffix}{}",
             status_text.as_deref().unwrap_or("")
         );
-        let line = Line::from(Span::raw(line_text));
 
-        let line = if is_selected {
-            Line::from(
-                line.spans
-                    .into_iter()
-                    .map(|s| Span::styled(s.content.to_string(), s.style.patch(th::QUOTA_SELECTED)))
-                    .collect::<Vec<_>>(),
-            )
+        // Too narrow — fall back to text-only rendering.
+        if area.width < 5 {
+            let line = Line::from(format!("{glyph} {plan_text}"));
+            let p = if is_selected {
+                Paragraph::new(line).style(th::QUOTA_SELECTED)
+            } else {
+                Paragraph::new(line)
+            };
+            frame.render_widget(p, Rect::new(area.x, row_y, area.width, 1));
+            continue;
+        }
+
+        // Split the row rect: [glyph:1][gap:1][logo:3][gap:1][text:rest]
+        let row_rect = Rect::new(area.x, row_y, area.width, 1);
+        let parts = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Length(1), // glyph
+                Constraint::Length(1), // gap
+                Constraint::Length(3), // logo
+                Constraint::Length(1), // gap
+                Constraint::Min(1),    // plan text
+            ])
+            .split(row_rect);
+
+        let glyph_rect = parts[0];
+        let logo_rect = parts[2];
+        let text_rect = parts[4];
+
+        // Glyph
+        let glyph_style = status_style(slot.current.ok, slot.last_good.is_some(), loading);
+        let glyph_p = Paragraph::new(Line::from(Span::styled(glyph.to_string(), glyph_style)));
+        frame.render_widget(glyph_p, glyph_rect);
+
+        // Plan text
+        let text_line = Line::from(Span::raw(plan_text));
+        let text_p = if is_selected {
+            Paragraph::new(text_line).style(th::QUOTA_SELECTED)
         } else {
-            line
+            Paragraph::new(text_line)
         };
-        lines.push(line);
-    }
+        frame.render_widget(text_p, text_rect);
 
-    let p = Paragraph::new(lines);
-    frame.render_widget(p, area);
+        // Logo (if available)
+        let provider_id = slot.current.provider_id;
+        if let Some(client_kind) = provider_id_to_client_kind(provider_id) {
+            if let Some(proto) = app.logo(client_kind) {
+                let img = Image::new(proto);
+                frame.render_widget(img, logo_rect);
+            }
+        }
+        // No logo → logo_rect stays blank (already cleared by ratatui).
+    }
 }
 
 fn render_details(frame: &mut Frame<'_>, area: Rect, app: &App) {

--- a/crates/agtop-cli/src/tui/widgets/dashboard_plan.rs
+++ b/crates/agtop-cli/src/tui/widgets/dashboard_plan.rs
@@ -13,7 +13,6 @@ use ratatui::{
 
 use crate::tui::app::{App, QuotaState};
 use crate::tui::theme as th;
-use crate::tui::widgets::quota_bar::provider_short_name;
 use agtop_core::quota::UsageWindow;
 use indexmap::IndexMap;
 
@@ -84,7 +83,7 @@ fn render_list(frame: &mut Frame<'_>, area: Rect, app: &App) {
         let is_selected = i == selected;
         let stale = !slot.current.ok && slot.last_good.is_some();
         let errored = !slot.current.ok && slot.last_good.is_none();
-        let loading = slot.current.usage.is_none() && slot.current.ok;
+        let loading = slot.current.usage.is_none() && slot.current.ok; // ok but no data yet
 
         let glyph = status_glyph(slot.current.ok, slot.last_good.is_some(), loading);
         let name_suffix = if stale { " \u{2020}" } else { "" };
@@ -172,6 +171,7 @@ fn render_list(frame: &mut Frame<'_>, area: Rect, app: &App) {
 }
 
 fn render_details(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    use crate::tui::widgets::quota_bar::provider_short_name;
     const BAR_WIDTH: usize = 10;
     const LABEL_WIDTH: usize = 16;
 

--- a/crates/agtop-cli/src/tui/widgets/dashboard_plan.rs
+++ b/crates/agtop-cli/src/tui/widgets/dashboard_plan.rs
@@ -69,7 +69,6 @@ fn render_list(frame: &mut Frame<'_>, area: Rect, app: &App) {
         error_token, provider_short_name, status_glyph, status_style,
     };
     use agtop_core::logo::provider_id_to_client_kind;
-    use ratatui_image::Image;
 
     let slots = app.quota_slots();
     let selected = app.selected_provider();
@@ -127,16 +126,19 @@ fn render_list(frame: &mut Frame<'_>, area: Rect, app: &App) {
             continue;
         }
 
-        // Split the row rect: [glyph:1][gap:1][logo:3][gap:1][text:rest]
+        // Split the row rect. When no logos are loaded (terminal without
+        // a graphics protocol) we collapse the logo slot to zero width so
+        // the plan text doesn't get gratuitously indented past empty cells.
+        let show_logo = app.has_logos();
         let row_rect = Rect::new(area.x, row_y, area.width, 1);
         let parts = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([
-                Constraint::Length(1), // glyph
-                Constraint::Length(1), // gap
-                Constraint::Length(3), // logo
-                Constraint::Length(1), // gap
-                Constraint::Min(1),    // plan text
+                Constraint::Length(1),                             // glyph
+                Constraint::Length(1),                             // gap
+                Constraint::Length(if show_logo { 3 } else { 0 }), // logo
+                Constraint::Length(if show_logo { 1 } else { 0 }), // gap
+                Constraint::Min(1),                                // plan text
             ])
             .split(row_rect);
 
@@ -158,12 +160,11 @@ fn render_list(frame: &mut Frame<'_>, area: Rect, app: &App) {
         };
         frame.render_widget(text_p, text_rect);
 
-        // Logo (if available)
+        // Logo (if available) — stamp pre-rendered cells.
         let provider_id = slot.current.provider_id;
         if let Some(client_kind) = provider_id_to_client_kind(provider_id) {
-            if let Some(proto) = app.logo(client_kind) {
-                let img = Image::new(proto);
-                frame.render_widget(img, logo_rect);
+            if let Some(cells) = app.logo(client_kind) {
+                crate::tui::paste_logo_cells(frame.buffer_mut(), logo_rect, cells);
             }
         }
         // No logo → logo_rect stays blank (already cleared by ratatui).

--- a/crates/agtop-cli/src/tui/widgets/info_tab.rs
+++ b/crates/agtop-cli/src/tui/widgets/info_tab.rs
@@ -119,22 +119,31 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
                     ]));
                 }
             }
+            // Logo width in terminal cells: must stay in sync with the number of
+            // spaces prepended to the subscription value span below.
+            const LOGO_WIDTH: u16 = 3;
+
             // Determine which line index corresponds to the Subscription row.
-            // ColumnId::all() order determines line index (0-based after optional parent line).
+            // sub_line_idx is correct because extra lines (effective_model,
+            // data_path, billing, state_detail, effort_detail, subagent rows)
+            // are all appended AFTER the ColumnId::all() block — the only line
+            // inserted BEFORE it is the optional parent backlink.
+            let parent_line_offset: usize = if parent_id.is_some() { 1 } else { 0 };
             let sub_col_pos = ColumnId::all()
                 .iter()
-                .position(|&c| c == ColumnId::Subscription)
-                .unwrap_or(0);
-            let parent_line_offset: usize = if parent_id.is_some() { 1 } else { 0 };
-            let sub_line_idx = parent_line_offset + sub_col_pos;
+                .position(|&c| c == ColumnId::Subscription);
+            let sub_line_idx = sub_col_pos.map(|pos| parent_line_offset + pos);
 
-            // Prepend 3 spaces to the subscription value span so the logo can
-            // overlay that blank area later.
-            if let Some(line) = lines.get_mut(sub_line_idx) {
-                // kv_line format: [key_span(idx 0)][gap_span(idx 1)][value_span(idx 2)]
-                if let Some(value_span) = line.spans.get_mut(2) {
-                    let original = value_span.content.to_string();
-                    value_span.content = format!("   {original}").into();
+            // Prepend LOGO_WIDTH spaces to the subscription value span so the
+            // logo image can overlay that blank area after paragraph rendering.
+            if let Some(idx) = sub_line_idx {
+                if let Some(line) = lines.get_mut(idx) {
+                    // kv_line format: [key_span(idx 0)][gap_span(idx 1)][value_span(idx 2)]
+                    if let Some(value_span) = line.spans.get_mut(2) {
+                        let original = value_span.content.to_string();
+                        let padding = " ".repeat(LOGO_WIDTH as usize);
+                        value_span.content = format!("{padding}{original}").into();
+                    }
                 }
             }
 
@@ -164,31 +173,33 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
             );
 
             // Overlay the provider logo on the subscription line.
-            // Key is right-aligned in 16 chars, then 2-char gap → value starts at col x+18.
-            // The 3 prepended spaces give us a 3-wide cell for the logo image.
-            let logo_col_rect;
-            let logo_line_in_col;
-            if sub_line_idx < split {
-                // Subscription is in the left column.
-                logo_col_rect = cols[0];
-                logo_line_in_col = sub_line_idx;
-            } else {
-                // Subscription is in the right column.
-                logo_col_rect = cols[1];
-                logo_line_in_col = sub_line_idx - split;
-            }
+            // Key is right-aligned in 16 chars, then 2-char gap → value starts
+            // at col x+18. The LOGO_WIDTH prepended spaces are the logo cell.
+            if let Some(idx) = sub_line_idx {
+                let logo_col_rect;
+                let logo_line_in_col;
+                if idx < split {
+                    // Subscription is in the left column.
+                    logo_col_rect = cols[0];
+                    logo_line_in_col = idx;
+                } else {
+                    // Subscription is in the right column.
+                    logo_col_rect = cols[1];
+                    logo_line_in_col = idx - split;
+                }
 
-            let logo_y = logo_col_rect.y + logo_line_in_col as u16;
-            // key (16) + gap (2) = 18 chars before the value starts
-            let logo_x = logo_col_rect.x + 18;
+                let logo_y = logo_col_rect.y + logo_line_in_col as u16;
+                // key (16 chars) + gap (2 chars) = 18 chars before value starts
+                let logo_x = logo_col_rect.x + 18;
 
-            if logo_y < logo_col_rect.y + logo_col_rect.height
-                && logo_x + 3 <= logo_col_rect.x + logo_col_rect.width
-            {
-                let logo_rect = Rect::new(logo_x, logo_y, 3, 1);
-                let client = a.summary.client;
-                if let Some(proto) = app.logo(client) {
-                    frame.render_widget(Image::new(proto), logo_rect);
+                if logo_y < logo_col_rect.y + logo_col_rect.height
+                    && logo_x + LOGO_WIDTH <= logo_col_rect.x + logo_col_rect.width
+                {
+                    let logo_rect = Rect::new(logo_x, logo_y, LOGO_WIDTH, 1);
+                    let client = a.summary.client;
+                    if let Some(proto) = app.logo(client) {
+                        frame.render_widget(Image::new(proto), logo_rect);
+                    }
                 }
             }
 

--- a/crates/agtop-cli/src/tui/widgets/info_tab.rs
+++ b/crates/agtop-cli/src/tui/widgets/info_tab.rs
@@ -13,6 +13,7 @@ use crate::tui::column_config::ColumnId;
 use crate::tui::theme as th;
 use crate::tui::widgets::state_display::display_state;
 use agtop_core::session::SessionAnalysis;
+use ratatui_image::Image;
 
 pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let block = Block::default().borders(Borders::ALL).title(" Info ");
@@ -118,6 +119,25 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
                     ]));
                 }
             }
+            // Determine which line index corresponds to the Subscription row.
+            // ColumnId::all() order determines line index (0-based after optional parent line).
+            let sub_col_pos = ColumnId::all()
+                .iter()
+                .position(|&c| c == ColumnId::Subscription)
+                .unwrap_or(0);
+            let parent_line_offset: usize = if parent_id.is_some() { 1 } else { 0 };
+            let sub_line_idx = parent_line_offset + sub_col_pos;
+
+            // Prepend 3 spaces to the subscription value span so the logo can
+            // overlay that blank area later.
+            if let Some(line) = lines.get_mut(sub_line_idx) {
+                // kv_line format: [key_span(idx 0)][gap_span(idx 1)][value_span(idx 2)]
+                if let Some(value_span) = line.spans.get_mut(2) {
+                    let original = value_span.content.to_string();
+                    value_span.content = format!("   {original}").into();
+                }
+            }
+
             // Split lines across two columns for better space utilisation.
             // The first column gets the metadata fields; the second gets any
             // child/subagent rows so they stay together.
@@ -142,6 +162,36 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 Paragraph::new(right_lines).wrap(Wrap { trim: false }),
                 cols[1],
             );
+
+            // Overlay the provider logo on the subscription line.
+            // Key is right-aligned in 16 chars, then 2-char gap → value starts at col x+18.
+            // The 3 prepended spaces give us a 3-wide cell for the logo image.
+            let logo_col_rect;
+            let logo_line_in_col;
+            if sub_line_idx < split {
+                // Subscription is in the left column.
+                logo_col_rect = cols[0];
+                logo_line_in_col = sub_line_idx;
+            } else {
+                // Subscription is in the right column.
+                logo_col_rect = cols[1];
+                logo_line_in_col = sub_line_idx - split;
+            }
+
+            let logo_y = logo_col_rect.y + logo_line_in_col as u16;
+            // key (16) + gap (2) = 18 chars before the value starts
+            let logo_x = logo_col_rect.x + 18;
+
+            if logo_y < logo_col_rect.y + logo_col_rect.height
+                && logo_x + 3 <= logo_col_rect.x + logo_col_rect.width
+            {
+                let logo_rect = Rect::new(logo_x, logo_y, 3, 1);
+                let client = a.summary.client;
+                if let Some(proto) = app.logo(client) {
+                    frame.render_widget(Image::new(proto), logo_rect);
+                }
+            }
+
             return;
         }
     };

--- a/crates/agtop-cli/src/tui/widgets/info_tab.rs
+++ b/crates/agtop-cli/src/tui/widgets/info_tab.rs
@@ -13,7 +13,6 @@ use crate::tui::column_config::ColumnId;
 use crate::tui::theme as th;
 use crate::tui::widgets::state_display::display_state;
 use agtop_core::session::SessionAnalysis;
-use ratatui_image::Image;
 
 pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let block = Block::default().borders(Borders::ALL).title(" Info ");
@@ -121,7 +120,7 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
             }
             // Logo width in terminal cells: must stay in sync with the number of
             // spaces prepended to the subscription value span below.
-            const LOGO_WIDTH: u16 = 3;
+            const LOGO_WIDTH: u16 = crate::tui::LOGO_WIDTH;
 
             // Determine which line index corresponds to the Subscription row.
             // sub_line_idx is correct because extra lines (effective_model,
@@ -134,15 +133,20 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 .position(|&c| c == ColumnId::Subscription);
             let sub_line_idx = sub_col_pos.map(|pos| parent_line_offset + pos);
 
-            // Prepend LOGO_WIDTH spaces to the subscription value span so the
-            // logo image can overlay that blank area after paragraph rendering.
-            if let Some(idx) = sub_line_idx {
-                if let Some(line) = lines.get_mut(idx) {
-                    // kv_line format: [key_span(idx 0)][gap_span(idx 1)][value_span(idx 2)]
-                    if let Some(value_span) = line.spans.get_mut(2) {
-                        let original = value_span.content.to_string();
-                        let padding = " ".repeat(LOGO_WIDTH as usize);
-                        value_span.content = format!("{padding}{original}").into();
+            // Prepend LOGO_WIDTH spaces to the subscription value span so
+            // the logo image can overlay that blank area after paragraph
+            // rendering. Skip on terminals without a graphics protocol
+            // (no logos loaded) so the value isn't gratuitously indented.
+            let show_logo = app.has_logos();
+            if show_logo {
+                if let Some(idx) = sub_line_idx {
+                    if let Some(line) = lines.get_mut(idx) {
+                        // kv_line format: [key_span(idx 0)][gap_span(idx 1)][value_span(idx 2)]
+                        if let Some(value_span) = line.spans.get_mut(2) {
+                            let original = value_span.content.to_string();
+                            let padding = " ".repeat(LOGO_WIDTH as usize);
+                            value_span.content = format!("{padding}{original}").into();
+                        }
                     }
                 }
             }
@@ -175,30 +179,32 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
             // Overlay the provider logo on the subscription line.
             // Key is right-aligned in 16 chars, then 2-char gap → value starts
             // at col x+18. The LOGO_WIDTH prepended spaces are the logo cell.
-            if let Some(idx) = sub_line_idx {
-                let logo_col_rect;
-                let logo_line_in_col;
-                if idx < split {
-                    // Subscription is in the left column.
-                    logo_col_rect = cols[0];
-                    logo_line_in_col = idx;
-                } else {
-                    // Subscription is in the right column.
-                    logo_col_rect = cols[1];
-                    logo_line_in_col = idx - split;
-                }
+            if show_logo {
+                if let Some(idx) = sub_line_idx {
+                    let logo_col_rect;
+                    let logo_line_in_col;
+                    if idx < split {
+                        // Subscription is in the left column.
+                        logo_col_rect = cols[0];
+                        logo_line_in_col = idx;
+                    } else {
+                        // Subscription is in the right column.
+                        logo_col_rect = cols[1];
+                        logo_line_in_col = idx - split;
+                    }
 
-                let logo_y = logo_col_rect.y + logo_line_in_col as u16;
-                // key (16 chars) + gap (2 chars) = 18 chars before value starts
-                let logo_x = logo_col_rect.x + 18;
+                    let logo_y = logo_col_rect.y + logo_line_in_col as u16;
+                    // key (16 chars) + gap (2 chars) = 18 chars before value starts
+                    let logo_x = logo_col_rect.x + 18;
 
-                if logo_y < logo_col_rect.y + logo_col_rect.height
-                    && logo_x + LOGO_WIDTH <= logo_col_rect.x + logo_col_rect.width
-                {
-                    let logo_rect = Rect::new(logo_x, logo_y, LOGO_WIDTH, 1);
-                    let client = a.summary.client;
-                    if let Some(proto) = app.logo(client) {
-                        frame.render_widget(Image::new(proto), logo_rect);
+                    if logo_y < logo_col_rect.y + logo_col_rect.height
+                        && logo_x + LOGO_WIDTH <= logo_col_rect.x + logo_col_rect.width
+                    {
+                        let logo_rect = Rect::new(logo_x, logo_y, LOGO_WIDTH, 1);
+                        let client = a.summary.client;
+                        if let Some(cells) = app.logo(client) {
+                            crate::tui::paste_logo_cells(frame.buffer_mut(), logo_rect, cells);
+                        }
                     }
                 }
             }

--- a/crates/agtop-cli/src/tui/widgets/info_tab.rs
+++ b/crates/agtop-cli/src/tui/widgets/info_tab.rs
@@ -251,6 +251,8 @@ fn column_line(col: ColumnId, a: &SessionAnalysis, now: DateTime<Utc>) -> Line<'
             s.session_title.clone().unwrap_or_else(|| "-".into()),
         ),
         ColumnId::Cwd => kv_line("cwd", s.cwd.clone().unwrap_or_else(|| "-".into())),
+        // SubscriptionLogo is injected by visible() — not displayed in info tab.
+        ColumnId::SubscriptionLogo => Line::default(),
     }
 }
 

--- a/crates/agtop-cli/src/tui/widgets/quota_bar.rs
+++ b/crates/agtop-cli/src/tui/widgets/quota_bar.rs
@@ -78,6 +78,19 @@ pub fn error_token(err: &QuotaError) -> String {
     }
 }
 
+/// Returns the ratatui `Style` for the status glyph (● / ✗ / ▲ / ○).
+pub fn status_style(ok: bool, has_last_good: bool, loading: bool) -> Style {
+    if ok && !loading {
+        th::QUOTA_BAR_OK
+    } else if !ok && has_last_good {
+        th::QUOTA_BAR_STALE
+    } else if loading {
+        th::QUOTA_BAR_STALE
+    } else {
+        th::QUOTA_BAR_CRIT
+    }
+}
+
 /// Status glyph for the Dashboard list column.
 #[allow(dead_code)]
 pub fn status_glyph(current_ok: bool, last_good_some: bool, loading: bool) -> char {

--- a/crates/agtop-cli/src/tui/widgets/quota_bar.rs
+++ b/crates/agtop-cli/src/tui/widgets/quota_bar.rs
@@ -80,14 +80,14 @@ pub fn error_token(err: &QuotaError) -> String {
 
 /// Returns the ratatui `Style` for the status glyph (● / ✗ / ▲ / ○).
 pub fn status_style(ok: bool, has_last_good: bool, loading: bool) -> Style {
-    if ok && !loading {
-        th::QUOTA_BAR_OK
-    } else if !ok && has_last_good {
-        th::QUOTA_BAR_STALE
-    } else if loading {
-        th::QUOTA_BAR_STALE
+    if loading {
+        th::QUOTA_BAR_STALE // loading spinner ○ — always amber
+    } else if ok {
+        th::QUOTA_BAR_OK // healthy ●
+    } else if has_last_good {
+        th::QUOTA_BAR_STALE // stale ▲
     } else {
-        th::QUOTA_BAR_CRIT
+        th::QUOTA_BAR_CRIT // error ✗
     }
 }
 

--- a/crates/agtop-cli/src/tui/widgets/session_table.rs
+++ b/crates/agtop-cli/src/tui/widgets/session_table.rs
@@ -23,12 +23,17 @@ use crate::tui::widgets::state_display::display_state;
 ///
 /// `header_cols` is overwritten with the absolute terminal x-ranges of
 /// every sortable header cell so the mouse handler can hit-test clicks.
+///
+/// `logo_rects` is overwritten with one entry per visible data row: the
+/// `Rect` of the `SubscriptionLogo` cell for that row, paired with the
+/// `ClientKind` of that session.
 pub fn render(
     frame: &mut Frame<'_>,
     area: Rect,
     app: &App,
     state: &mut TableState,
     header_cols: &mut Vec<(u16, u16, SortColumn)>,
+    logo_rects: &mut Vec<(Rect, agtop_core::ClientKind)>,
 ) {
     // Sync the widget's idea of selection with the app's.
     state.select(app.selected_idx());
@@ -141,13 +146,42 @@ pub fn render(
         })
         .collect();
 
-    let table = Table::new(rows, widths)
+    let table = Table::new(rows, widths.clone())
         .header(header)
         .block(Block::default().borders(Borders::ALL).title(title))
         .row_highlight_style(th::SELECTED)
         .highlight_symbol("▶ ");
 
     frame.render_stateful_widget(table, area, state);
+
+    // ── Compute SubscriptionLogo column rects for the post-table overlay ──
+    //
+    // Find the index of SubscriptionLogo in the visible column list, then
+    // re-use the same layout split that was already computed for header_cols
+    // to determine where that column lands on screen for each data row.
+    let logo_col_idx = visible
+        .iter()
+        .position(|&c| c == ColumnId::SubscriptionLogo);
+
+    logo_rects.clear();
+
+    if let Some(logo_idx) = logo_col_idx {
+        // Reuse col_rects (already computed above for header_cols).
+        let logo_col_rect = col_rects[logo_idx];
+
+        // Data rows start at area.y + 2 (border row + header row).
+        let data_start_y = area.y + 2;
+
+        for (row_idx, (analysis, _is_child)) in view.iter().enumerate() {
+            let screen_row = data_start_y + row_idx as u16;
+            if screen_row >= area.y + area.height.saturating_sub(1) {
+                break; // outside the visible area (bottom border)
+            }
+            let rect = Rect::new(logo_col_rect.x, screen_row, logo_col_rect.width, 1);
+            logo_rects.push((rect, analysis.summary.client));
+        }
+    }
+    // ─────────────────────────────────────────────────────────────────────
 }
 
 fn header_cell(s: &'static str) -> Cell<'static> {

--- a/crates/agtop-cli/src/tui/widgets/session_table.rs
+++ b/crates/agtop-cli/src/tui/widgets/session_table.rs
@@ -323,6 +323,8 @@ fn row_for<'a>(
             ColumnId::SessionName => {
                 Cell::from(s.session_title.clone().unwrap_or_else(|| "-".into()))
             }
+            // SubscriptionLogo is injected by visible() — rendered as empty for now.
+            ColumnId::SubscriptionLogo => Cell::from(""),
         })
         .collect();
 

--- a/crates/agtop-cli/src/tui/widgets/session_table.rs
+++ b/crates/agtop-cli/src/tui/widgets/session_table.rs
@@ -100,6 +100,7 @@ pub fn render(
     let columns_width = inner_width.saturating_sub(selection_width);
 
     // Split exactly as Table does: Layout::horizontal(widths).spacing(1).
+    // clone: widths ownership is needed by Table::new below.
     let col_rects = Layout::default()
         .direction(Direction::Horizontal)
         .constraints(widths.clone())
@@ -167,13 +168,18 @@ pub fn render(
 
     if let Some(logo_idx) = logo_col_idx {
         // Reuse col_rects (already computed above for header_cols).
+        // Only x and width are used from col_rects (y is the header row;
+        // we replace it with screen_row below).
         let logo_col_rect = col_rects[logo_idx];
 
         // Data rows start at area.y + 2 (border row + header row).
         let data_start_y = area.y + 2;
 
-        for (row_idx, (analysis, _is_child)) in view.iter().enumerate() {
-            let screen_row = data_start_y + row_idx as u16;
+        // Skip rows that are scrolled off the top; screen_row is relative
+        // to the first *visible* row, not the start of the view slice.
+        let scroll_offset = state.offset();
+        for (row_idx, (analysis, _is_child)) in view.iter().enumerate().skip(scroll_offset) {
+            let screen_row = data_start_y + (row_idx - scroll_offset) as u16;
             if screen_row >= area.y + area.height.saturating_sub(1) {
                 break; // outside the visible area (bottom border)
             }

--- a/crates/agtop-cli/src/tui/widgets/session_table.rs
+++ b/crates/agtop-cli/src/tui/widgets/session_table.rs
@@ -48,7 +48,10 @@ pub fn render(
     };
 
     let col_cfg = app.column_config();
-    let visible = col_cfg.visible();
+    // Hide the SubscriptionLogo slot when no logos are loaded
+    // (terminals without a graphics protocol). Otherwise the column
+    // reserves dead space.
+    let visible = col_cfg.visible_ext(app.has_logos());
 
     let header_cells: Vec<Cell<'static>> = visible
         .iter()

--- a/crates/agtop-core/src/logo.rs
+++ b/crates/agtop-core/src/logo.rs
@@ -4,6 +4,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use crate::quota::ProviderId;
 use crate::session::ClientKind;
 
 pub const LOGO_BASE_URL: &str = "https://models.dev/logos";
@@ -21,6 +22,20 @@ pub fn logo_provider_id(client: ClientKind) -> Option<&'static str> {
         ClientKind::GeminiCli => Some("google"),
         ClientKind::Cursor => None,
         ClientKind::Antigravity => None,
+    }
+}
+
+/// Reverse of the `logo_provider_id` mapping: given a `ProviderId` return
+/// the `ClientKind` whose logo file represents that provider, or `None` when
+/// no client maps to that provider.
+pub fn provider_id_to_client_kind(provider_id: ProviderId) -> Option<ClientKind> {
+    match provider_id {
+        ProviderId::Claude => Some(ClientKind::Claude),
+        ProviderId::Codex => Some(ClientKind::Codex),
+        ProviderId::Copilot => Some(ClientKind::Copilot),
+        ProviderId::CopilotAddon => Some(ClientKind::Copilot), // shares logo
+        ProviderId::Zai => None,                               // no logo yet
+        ProviderId::Google => Some(ClientKind::GeminiCli),
     }
 }
 
@@ -122,5 +137,33 @@ mod tests {
         assert_eq!(logo_provider_id(ClientKind::GeminiCli), Some("google"));
         assert_eq!(logo_provider_id(ClientKind::Cursor), None);
         assert_eq!(logo_provider_id(ClientKind::Antigravity), None);
+    }
+
+    #[test]
+    fn provider_id_to_client_kind_round_trips() {
+        // Every ClientKind that has a logo_provider_id must round-trip back.
+        for &kind in ClientKind::all() {
+            if let Some(pid_str) = logo_provider_id(kind) {
+                // Map the string back to a ProviderId then back to ClientKind.
+                let provider_id = match pid_str {
+                    "anthropic" => ProviderId::Claude,
+                    "openai" => ProviderId::Codex,
+                    "opencode" => continue, // opencode has no ProviderId
+                    "github-copilot" => ProviderId::Copilot,
+                    "google" => ProviderId::Google,
+                    _ => continue,
+                };
+                let got = provider_id_to_client_kind(provider_id);
+                assert_eq!(got, Some(kind), "round-trip failed for {kind:?}");
+            }
+        }
+        // Variants not reachable from logo_provider_id must also be tested directly.
+        // CopilotAddon shares Copilot's logo.
+        assert_eq!(
+            provider_id_to_client_kind(ProviderId::CopilotAddon),
+            Some(ClientKind::Copilot)
+        );
+        // Zai has no logo yet.
+        assert_eq!(provider_id_to_client_kind(ProviderId::Zai), None);
     }
 }


### PR DESCRIPTION
## Summary

- Adds provider logos (Anthropic, OpenAI, Google, GitHub Copilot) next to subscription names in three TUI surfaces
- Logo and subscription are one logical unit: always displayed together, never separately configurable
- 3-column slot reserved on graphics-capable terminals; on halfblocks terminals (alacritty, VSCode terminal, etc.) the slot is omitted entirely so layout matches `main`

## Surfaces

- **Session table:** `SubscriptionLogo` hidden column (width 3) paired before `Subscription`; logos rendered in a second pass after table draw, using cached cells
- **Dashboard provider list:** row layout splits to `glyph · logo · plan name`
- **Info tab:** logo overlaid at start of subscription value, 3-char space reserved in text

## Implementation notes

- Logos load at startup from `models.dev/logos/<provider>.svg` with a 7-day on-disk cache (`~/.cache/agtop/logos/`)
- SVG is rasterized via `resvg`/`tiny-skia`, then encoded by `ratatui-image` once at init into a 3x1 scratch buffer; the resulting cells are cloned per frame to avoid rebuilding kilobyte-sized escape sequences in the hot path
- Halfblocks fallback is detected (`Picker::protocol_type()`) and the logo pipeline is skipped — no dead column, no indented info-tab value
- `provider_id_to_client_kind()` added to `agtop-core::logo` for dashboard ProviderId→logo lookup
- `--log-file <PATH>` flag added for TUI-safe diagnostic logging

## Code review fixes (post-initial review)

1. **Wrong logo content rendered.** `Picker::new_protocol` was called with `Rect::new(0,0,1,1)` — the SVG was being encoded into a single character cell, then rendered into a 3-cell rect, leaving 2 cells unmapped. Fixed by encoding at the real target size (3x1).
2. **~30 ms per frame CPU on the Kitty graphics protocol.** `Image::render` was being called for every visible row on every redraw, rebuilding the kitty placeholder escape sequence each time. Fixed by rendering each protocol once at init time into a scratch `Buffer` and caching the resulting cells; the per-frame path now does cheap `Cell` clones.
3. **No icon on alacritty / VSCode terminal.** Halfblocks at 3x2 px is unrecognizable noise. Fixed by detecting the protocol and skipping logos entirely on those terminals — `App::has_logos()` gates the column injection in session table, info tab, and dashboard plan list.

## Known follow-up

Startup time (debug builds especially, but also noticeable in release on machines with many sessions) feels slow. The added logo init is ~25 ms and is not the cause; tracing shows the bulk of wall time is the pre-existing background session-analysis pipeline. Tracked separately so this PR can land.

Closes #20