### PR TITLE
refactor(core): replace waiting/stopped states with running/blocked/idle/closed

### DIFF
--- a/crates/agtop-cli/src/main.rs
+++ b/crates/agtop-cli/src/main.rs
@@ -637,7 +637,7 @@ impl JsonSession {
             cwd: a.summary.cwd.clone(),
             started_at: a.summary.started_at,
             last_active: a.summary.last_active,
-            state: a.summary.state.clone(),
+            state: a.summary.state.as_ref().map(|s| s.as_str().to_string()),
             display_state: display_state_label.to_string(),
             state_detail: a.summary.state_detail.clone(),
             model_effort: a.summary.model_effort.clone(),
@@ -661,7 +661,7 @@ impl JsonSession {
 #[cfg(test)]
 mod json_output_tests {
     use super::*;
-    use agtop_core::session::{ClientKind, CostBreakdown, SessionSummary, TokenTotals};
+    use agtop_core::session::{ClientKind, CostBreakdown, SessionState, SessionSummary, TokenTotals};
     use std::path::PathBuf;
 
     #[test]
@@ -676,7 +676,7 @@ mod json_output_tests {
             Some("model".into()),
             Some("/tmp".into()),
             PathBuf::from("/tmp/sess.json"),
-            Some("stopped".into()),
+            Some(SessionState::Closed),
             Some("finish=stop".into()),
             None,
             None,
@@ -696,8 +696,8 @@ mod json_output_tests {
 
         let json = JsonSession::from_analysis(&analysis, now);
 
-        assert_eq!(json.state.as_deref(), Some("stopped"));
-        assert_eq!(json.display_state, "working");
+        assert_eq!(json.state.as_deref(), Some("closed"));
+        assert_eq!(json.display_state, "closed");
     }
 
     #[test]

--- a/crates/agtop-cli/src/main.rs
+++ b/crates/agtop-cli/src/main.rs
@@ -588,7 +588,7 @@ struct JsonSession {
     cwd: Option<String>,
     started_at: Option<DateTime<Utc>>,
     last_active: Option<DateTime<Utc>>,
-    state: Option<String>,
+    state: Option<agtop_core::session::SessionState>,
     display_state: String,
     state_detail: Option<String>,
     model_effort: Option<String>,
@@ -637,7 +637,7 @@ impl JsonSession {
             cwd: a.summary.cwd.clone(),
             started_at: a.summary.started_at,
             last_active: a.summary.last_active,
-            state: a.summary.state.as_ref().map(|s| s.as_str().to_string()),
+            state: a.summary.state,
             display_state: display_state_label.to_string(),
             state_detail: a.summary.state_detail.clone(),
             model_effort: a.summary.model_effort.clone(),
@@ -661,7 +661,10 @@ impl JsonSession {
 #[cfg(test)]
 mod json_output_tests {
     use super::*;
-    use agtop_core::session::{ClientKind, CostBreakdown, SessionState, SessionSummary, TokenTotals};
+    use agtop_core::session::{
+        ClientKind, CostBreakdown, SessionState, SessionSummary, TokenTotals,
+    };
+    use agtop_core::Liveness;
     use std::path::PathBuf;
 
     #[test]
@@ -676,12 +679,12 @@ mod json_output_tests {
             Some("model".into()),
             Some("/tmp".into()),
             PathBuf::from("/tmp/sess.json"),
-            Some(SessionState::Closed),
+            Some(SessionState::Idle),
             Some("finish=stop".into()),
             None,
             None,
         );
-        let analysis = SessionAnalysis::new(
+        let mut analysis = SessionAnalysis::new(
             summary,
             TokenTotals::default(),
             CostBreakdown::default(),
@@ -693,11 +696,13 @@ mod json_output_tests {
             None,
             None,
         );
+        analysis.pid = Some(42);
+        analysis.liveness = Some(Liveness::Live);
 
         let json = JsonSession::from_analysis(&analysis, now);
 
-        assert_eq!(json.state.as_deref(), Some("closed"));
-        assert_eq!(json.display_state, "closed");
+        assert_eq!(json.state, Some(SessionState::Idle));
+        assert_eq!(json.display_state, "idle");
     }
 
     #[test]

--- a/crates/agtop-cli/src/main.rs
+++ b/crates/agtop-cli/src/main.rs
@@ -159,6 +159,7 @@ fn main() -> Result<()> {
         let summaries: Vec<_> = analyses.iter().map(|a| a.summary.clone()).collect();
         let info_map = agtop_core::ProcessCorrelator::new().snapshot(&summaries);
         agtop_core::process::attach_process_info(&info_map, &mut analyses);
+        agtop_core::resolve_session_states(&mut analyses, Utc::now());
         let out = JsonOutput {
             plan: cli.plan.clone(),
             sessions: analyses.iter().map(JsonSession::from).collect(),
@@ -703,6 +704,43 @@ mod json_output_tests {
 
         assert_eq!(json.state, Some(SessionState::Idle));
         assert_eq!(json.display_state, "idle");
+    }
+
+    #[test]
+    fn json_session_reports_closed_after_resolution_for_non_live_session() {
+        let now = Utc::now();
+        let summary = SessionSummary::new(
+            ClientKind::OpenCode,
+            None,
+            "sess".into(),
+            Some(now - chrono::Duration::minutes(10)),
+            Some(now - chrono::Duration::minutes(10)),
+            Some("model".into()),
+            Some("/tmp".into()),
+            PathBuf::from("/tmp/sess.json"),
+            Some(SessionState::Idle),
+            Some("finish=stop".into()),
+            None,
+            None,
+        );
+        let mut analyses = vec![SessionAnalysis::new(
+            summary,
+            TokenTotals::default(),
+            CostBreakdown::default(),
+            None,
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )];
+
+        agtop_core::resolve_session_states(&mut analyses, now);
+        let json = JsonSession::from_analysis(&analyses[0], now);
+
+        assert_eq!(json.state, Some(SessionState::Closed));
+        assert_eq!(json.display_state, "closed");
     }
 
     #[test]

--- a/crates/agtop-cli/src/tui/mod.rs
+++ b/crates/agtop-cli/src/tui/mod.rs
@@ -827,7 +827,7 @@ mod tests {
     use crate::tui::column_config::ColumnId;
     use crate::version;
     use agtop_core::session::{
-        ClientKind, CostBreakdown, SessionAnalysis, SessionSummary, TokenTotals,
+        ClientKind, CostBreakdown, SessionAnalysis, SessionState, SessionSummary, TokenTotals,
     };
     use chrono::{TimeZone, Utc};
     use ratatui::backend::TestBackend;
@@ -854,7 +854,7 @@ mod tests {
             Some("claude-opus-4-6".into()),
             Some("/tmp/proj".into()),
             PathBuf::from("/tmp/deadbeef.jsonl"),
-            Some("waiting".into()),
+            Some(SessionState::Blocked),
             Some("tool approval pending".into()),
             Some("high".into()),
             Some("reasoning.effort=high".into()),
@@ -868,7 +868,7 @@ mod tests {
         s1_cost.output = 0.0075;
         s1_cost.cache_read = 0.010;
         s1_cost.total = 0.0205;
-        let s1 = SessionAnalysis::new(
+        let mut s1 = SessionAnalysis::new(
             s1_summary,
             s1_tokens,
             s1_cost,
@@ -880,6 +880,8 @@ mod tests {
             None,
             None,
         );
+        s1.pid = Some(12345);
+        s1.liveness = Some(agtop_core::process::Liveness::Live);
 
         let s2_summary = SessionSummary::new(
             ClientKind::Codex,
@@ -944,7 +946,7 @@ mod tests {
         assert!(contents.contains("Info"), "Info tab title missing");
         assert!(contents.contains("STATE"), "state header missing");
         assert!(contents.contains("EFFORT"), "effort header missing");
-        assert!(contents.contains("waiting"), "state value missing");
+        assert!(contents.contains("blocked"), "state value missing");
         assert!(contents.contains("high"), "effort value missing");
         assert!(
             contents.contains(version::display_version()),
@@ -1023,7 +1025,7 @@ mod tests {
             Some("model".into()),
             Some("/tmp/proj".into()),
             PathBuf::from("/tmp/working.json"),
-            Some("stopped".into()),
+            Some(SessionState::Closed),
             Some("finish=stop".into()),
             None,
             None,

--- a/crates/agtop-cli/src/tui/mod.rs
+++ b/crates/agtop-cli/src/tui/mod.rs
@@ -835,13 +835,13 @@ mod tests {
 
     /// Tiny fixture: two sessions, Claude + Codex.
     ///
-    /// `s1_last` uses `Utc::now()` so the "waiting" state check always
+    /// `s1_last` uses `Utc::now()` so the "permit" state check always
     /// falls within `WAITING_STALE_SECS` regardless of when the test runs.
     fn fixture_app() -> App {
         let ts_started = Utc.with_ymd_and_hms(2026, 1, 1, 10, 0, 0).unwrap();
         let ts_last = Utc.with_ymd_and_hms(2026, 1, 1, 10, 30, 0).unwrap();
-        // Use a recent timestamp for the waiting session so `display_state`
-        // returns "waiting" rather than "stale" (sessions inactive for
+        // Use a recent timestamp for the permit session so `display_state`
+        // returns "permit" rather than "stale" (sessions inactive for
         // > WAITING_STALE_SECS are classified as stale even if waiting).
         let s1_last = Utc::now();
 
@@ -854,7 +854,7 @@ mod tests {
             Some("claude-opus-4-6".into()),
             Some("/tmp/proj".into()),
             PathBuf::from("/tmp/deadbeef.jsonl"),
-            Some(SessionState::Blocked),
+            Some(SessionState::AwaitingPermission),
             Some("tool approval pending".into()),
             Some("high".into()),
             Some("reasoning.effort=high".into()),
@@ -946,7 +946,7 @@ mod tests {
         assert!(contents.contains("Info"), "Info tab title missing");
         assert!(contents.contains("STATE"), "state header missing");
         assert!(contents.contains("EFFORT"), "effort header missing");
-        assert!(contents.contains("blocked"), "state value missing");
+        assert!(contents.contains("permit"), "state value missing");
         assert!(contents.contains("high"), "effort value missing");
         assert!(
             contents.contains(version::display_version()),

--- a/crates/agtop-cli/src/tui/refresh.rs
+++ b/crates/agtop-cli/src/tui/refresh.rs
@@ -292,6 +292,7 @@ pub fn spawn(
                     let summaries: Vec<_> = analyses.iter().map(|a| a.summary.clone()).collect();
                     let info_map = correlator.snapshot(&summaries);
                     agtop_core::process::attach_process_info(&info_map, &mut analyses);
+                    agtop_core::resolve_session_states(&mut analyses, Utc::now());
 
                     RefreshMsg::Snapshot {
                         generation,
@@ -486,9 +487,15 @@ fn cached_analyze_all(
                             project_cache.get(&key).and_then(|v| v.clone());
                     }
                 }
-                // Note: children are cached with the parent; if only a child's
-                // last_active changes while the parent's is stable, the stale
-                // child data is served until the parent itself is re-analyzed.
+                if let Some(client) = clients.iter().find(|c| c.kind() == summary.client) {
+                    refresh_children(
+                        client.as_ref(),
+                        clients,
+                        summary,
+                        plan,
+                        &mut cached_analysis,
+                    );
+                }
                 out.push(cached_analysis);
                 continue;
             }
@@ -509,45 +516,7 @@ fn cached_analyze_all(
                     analysis.project_name = project_cache.get(&key).and_then(|v| v.clone());
                 }
 
-                match client.children(summary) {
-                    Ok(child_summaries) => {
-                        for child_summary in &child_summaries {
-                            let child_client = clients
-                                .iter()
-                                .find(|candidate| candidate.kind() == child_summary.client);
-                            let child_client = match child_client {
-                                Some(client) => client,
-                                None => {
-                                    tracing::debug!(
-                                        child = child_summary.session_id.as_str(),
-                                        "no client for child session"
-                                    );
-                                    continue;
-                                }
-                            };
-                            match child_client.analyze(child_summary, plan) {
-                                Ok(child_analysis) => {
-                                    analysis.children.push(child_analysis);
-                                }
-                                Err(e) => {
-                                    tracing::debug!(
-                                        child = child_summary.session_id.as_str(),
-                                        error = %e,
-                                        "child analyze failed, skipping"
-                                    );
-                                }
-                            }
-                        }
-                        analysis.subagent_file_count = child_summaries.len();
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            parent = summary.session_id.as_str(),
-                            error = %e,
-                            "children() failed, treating as empty"
-                        );
-                    }
-                }
+                refresh_children(client.as_ref(), clients, summary, plan, &mut analysis);
 
                 cache.insert(
                     summary.session_id.clone(),
@@ -564,6 +533,46 @@ fn cached_analyze_all(
     }
 
     (out, cache, project_cache)
+}
+
+fn refresh_children(
+    client: &dyn Client,
+    clients: &[Arc<dyn Client>],
+    summary: &agtop_core::session::SessionSummary,
+    plan: agtop_core::pricing::Plan,
+    analysis: &mut SessionAnalysis,
+) {
+    analysis.children.clear();
+    match client.children(summary) {
+        Ok(child_summaries) => {
+            for child_summary in &child_summaries {
+                let Some(child_client) = clients
+                    .iter()
+                    .find(|candidate| candidate.kind() == child_summary.client)
+                else {
+                    tracing::debug!(
+                        child = child_summary.session_id.as_str(),
+                        "no client for child session"
+                    );
+                    continue;
+                };
+                match child_client.analyze(child_summary, plan) {
+                    Ok(child_analysis) => analysis.children.push(child_analysis),
+                    Err(e) => tracing::debug!(
+                        child = child_summary.session_id.as_str(),
+                        error = %e,
+                        "child analyze failed, skipping"
+                    ),
+                }
+            }
+            analysis.subagent_file_count = child_summaries.len();
+        }
+        Err(e) => tracing::warn!(
+            parent = summary.session_id.as_str(),
+            error = %e,
+            "children() failed, treating as empty"
+        ),
+    }
 }
 
 #[cfg(test)]

--- a/crates/agtop-cli/src/tui/theme.rs
+++ b/crates/agtop-cli/src/tui/theme.rs
@@ -56,9 +56,10 @@ pub const COST_HIGH: Style = Style::new().fg(Color::Yellow);
 
 // ── Session state colours ──────────────────────────────────────────────────
 
-pub const STATE_WORKING: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
-pub const STATE_WAITING: Style = Style::new().fg(Color::Magenta).add_modifier(Modifier::BOLD);
-pub const STATE_STALE: Style = Style::new().fg(Color::Gray).add_modifier(Modifier::BOLD);
+pub const STATE_RUNNING: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+pub const STATE_BLOCKED: Style = Style::new().fg(Color::Magenta).add_modifier(Modifier::BOLD);
+pub const STATE_IDLE: Style = Style::new().fg(Color::Gray).add_modifier(Modifier::BOLD);
+pub const STATE_CLOSED: Style = Style::new().fg(Color::DarkGray).add_modifier(Modifier::BOLD);
 
 // ── Cost tab ─────────────────────────────────────────────────────────────
 

--- a/crates/agtop-cli/src/tui/theme.rs
+++ b/crates/agtop-cli/src/tui/theme.rs
@@ -59,7 +59,9 @@ pub const COST_HIGH: Style = Style::new().fg(Color::Yellow);
 pub const STATE_RUNNING: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
 pub const STATE_BLOCKED: Style = Style::new().fg(Color::Magenta).add_modifier(Modifier::BOLD);
 pub const STATE_IDLE: Style = Style::new().fg(Color::Gray).add_modifier(Modifier::BOLD);
-pub const STATE_CLOSED: Style = Style::new().fg(Color::DarkGray).add_modifier(Modifier::BOLD);
+pub const STATE_CLOSED: Style = Style::new()
+    .fg(Color::DarkGray)
+    .add_modifier(Modifier::BOLD);
 
 // ── Cost tab ─────────────────────────────────────────────────────────────
 

--- a/crates/agtop-cli/src/tui/theme.rs
+++ b/crates/agtop-cli/src/tui/theme.rs
@@ -57,11 +57,14 @@ pub const COST_HIGH: Style = Style::new().fg(Color::Yellow);
 // ── Session state colours ──────────────────────────────────────────────────
 
 pub const STATE_RUNNING: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
-pub const STATE_BLOCKED: Style = Style::new().fg(Color::Magenta).add_modifier(Modifier::BOLD);
 pub const STATE_IDLE: Style = Style::new().fg(Color::Gray).add_modifier(Modifier::BOLD);
 pub const STATE_CLOSED: Style = Style::new()
     .fg(Color::DarkGray)
     .add_modifier(Modifier::BOLD);
+pub const STATE_AWAITING_INPUT: Style = Style::new().fg(Color::Yellow);
+pub const STATE_AWAITING_PERMISSION: Style = Style::new().fg(Color::Red);
+pub const STATE_STALLED: Style = Style::new().fg(Color::DarkGray);
+pub const STATE_UNKNOWN: Style = Style::new().fg(Color::DarkGray);
 
 // ── Cost tab ─────────────────────────────────────────────────────────────
 

--- a/crates/agtop-cli/src/tui/widgets/info_tab.rs
+++ b/crates/agtop-cli/src/tui/widgets/info_tab.rs
@@ -123,7 +123,7 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
                             "  {} tok  ${:.4}  {}",
                             compact_tokens(child_tokens),
                             child.cost.total,
-                            cs.state.as_deref().unwrap_or("-"),
+                            cs.state.as_ref().map(|s| s.as_str()).unwrap_or("-"),
                         )),
                     ]));
                 }

--- a/crates/agtop-cli/src/tui/widgets/state_display.rs
+++ b/crates/agtop-cli/src/tui/widgets/state_display.rs
@@ -3,45 +3,40 @@ use ratatui::style::Style;
 
 use crate::tui::theme as th;
 
-const WORKING_WINDOW_SECS: i64 = 30;
-/// A session reporting "waiting" that has had no activity for this long is
-/// considered stale — the agent process likely died or was killed.
-const WAITING_STALE_SECS: i64 = 300; // 5 minutes
-
 pub fn display_state(
     a: &agtop_core::session::SessionAnalysis,
-    now: DateTime<Utc>,
+    _now: DateTime<Utc>,
 ) -> (&'static str, Style) {
-    let age_secs = a
-        .summary
-        .last_active
-        .map(|ts| (now - ts).num_seconds())
-        .unwrap_or(i64::MAX);
-
-    if a.summary.state.as_deref() == Some("waiting") && age_secs <= WAITING_STALE_SECS {
-        return ("waiting", th::STATE_WAITING);
+    if a.pid.is_none() || matches!(a.liveness, Some(agtop_core::process::Liveness::Stopped)) {
+        return ("closed", th::STATE_CLOSED);
     }
 
-    let is_recent = age_secs <= WORKING_WINDOW_SECS;
-
-    if is_recent {
-        ("working", th::STATE_WORKING)
-    } else {
-        ("stale", th::STATE_STALE)
+    match a.summary.state.unwrap_or(agtop_core::session::SessionState::Running) {
+        agtop_core::session::SessionState::Running => ("running", th::STATE_RUNNING),
+        agtop_core::session::SessionState::Blocked => ("blocked", th::STATE_BLOCKED),
+        agtop_core::session::SessionState::Idle => ("idle", th::STATE_IDLE),
+        agtop_core::session::SessionState::Closed => ("closed", th::STATE_CLOSED),
+        _ => ("closed", th::STATE_CLOSED),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agtop_core::process::Liveness;
     use agtop_core::session::{
-        ClientKind, CostBreakdown, SessionAnalysis, SessionSummary, TokenTotals,
+        ClientKind, CostBreakdown, SessionAnalysis, SessionState, SessionSummary, TokenTotals,
     };
     use chrono::TimeZone;
     use std::path::PathBuf;
 
-    fn analysis(state: Option<&str>, last_active: Option<DateTime<Utc>>) -> SessionAnalysis {
-        SessionAnalysis::new(
+    fn analysis(
+        state: Option<SessionState>,
+        last_active: Option<DateTime<Utc>>,
+        pid: Option<u32>,
+        liveness: Option<Liveness>,
+    ) -> SessionAnalysis {
+        let mut a = SessionAnalysis::new(
             SessionSummary::new(
                 ClientKind::Claude,
                 None,
@@ -51,7 +46,7 @@ mod tests {
                 Some("model".into()),
                 Some("/tmp".into()),
                 PathBuf::from("/tmp/sess.jsonl"),
-                state.map(str::to_string),
+                state,
                 None,
                 None,
                 None,
@@ -65,63 +60,64 @@ mod tests {
             None,
             None,
             None,
-        )
+        );
+        a.pid = pid;
+        a.liveness = liveness;
+        a
     }
 
     #[test]
-    fn waiting_state_maps_to_waiting_style() {
+    fn live_running_session_displays_running() {
         let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 0).unwrap();
-        let a = analysis(Some("waiting"), Some(now));
+        let a = analysis(Some(SessionState::Running), Some(now), Some(42), Some(Liveness::Live));
 
         let (label, style) = display_state(&a, now);
 
-        assert_eq!(label, "waiting");
-        assert_eq!(style, th::STATE_WAITING);
+        assert_eq!(label, "running");
+        assert_eq!(style, th::STATE_RUNNING);
     }
 
     #[test]
-    fn recent_non_waiting_session_maps_to_working() {
-        let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 30).unwrap();
-        let a = analysis(Some("stopped"), Some(now - chrono::Duration::seconds(10)));
+    fn live_blocked_session_displays_blocked() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 0).unwrap();
+        let a = analysis(Some(SessionState::Blocked), Some(now), Some(42), Some(Liveness::Live));
 
         let (label, style) = display_state(&a, now);
 
-        assert_eq!(label, "working");
-        assert_eq!(style, th::STATE_WORKING);
+        assert_eq!(label, "blocked");
+        assert_eq!(style, th::STATE_BLOCKED);
     }
 
     #[test]
-    fn old_non_waiting_session_maps_to_stale() {
-        let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 1, 0).unwrap();
-        let a = analysis(None, Some(now - chrono::Duration::seconds(45)));
+    fn live_idle_session_displays_idle() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 0).unwrap();
+        let a = analysis(Some(SessionState::Idle), Some(now), Some(42), Some(Liveness::Live));
 
         let (label, style) = display_state(&a, now);
 
-        assert_eq!(label, "stale");
-        assert_eq!(style, th::STATE_STALE);
+        assert_eq!(label, "idle");
+        assert_eq!(style, th::STATE_IDLE);
     }
 
     #[test]
-    fn waiting_state_older_than_stale_threshold_maps_to_stale() {
-        // A session stuck in "waiting" for > 5 minutes is stale (agent died).
-        let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 10, 0).unwrap();
-        let a = analysis(Some("waiting"), Some(now - chrono::Duration::seconds(301)));
+    fn no_pid_session_displays_closed() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 0).unwrap();
+        let a = analysis(Some(SessionState::Running), Some(now), None, None);
 
         let (label, style) = display_state(&a, now);
 
-        assert_eq!(label, "stale");
-        assert_eq!(style, th::STATE_STALE);
+        assert_eq!(label, "closed");
+        assert_eq!(style, th::STATE_CLOSED);
     }
 
     #[test]
-    fn waiting_state_within_stale_threshold_maps_to_waiting() {
-        // A session in "waiting" for < 5 minutes is still shown as waiting.
-        let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 10, 0).unwrap();
-        let a = analysis(Some("waiting"), Some(now - chrono::Duration::seconds(120)));
+    fn stopped_liveness_displays_closed() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 0).unwrap();
+        let a = analysis(Some(SessionState::Running), Some(now), Some(42), Some(Liveness::Stopped));
 
         let (label, style) = display_state(&a, now);
 
-        assert_eq!(label, "waiting");
-        assert_eq!(style, th::STATE_WAITING);
+        assert_eq!(label, "closed");
+        assert_eq!(style, th::STATE_CLOSED);
     }
 }

--- a/crates/agtop-cli/src/tui/widgets/state_display.rs
+++ b/crates/agtop-cli/src/tui/widgets/state_display.rs
@@ -14,13 +14,18 @@ pub fn display_state(
     match a
         .summary
         .state
-        .unwrap_or(agtop_core::session::SessionState::Running)
+        .unwrap_or(agtop_core::session::SessionState::Unknown)
     {
-        agtop_core::session::SessionState::Running => ("running", th::STATE_RUNNING),
-        agtop_core::session::SessionState::Blocked => ("blocked", th::STATE_BLOCKED),
+        agtop_core::session::SessionState::Running => ("run", th::STATE_RUNNING),
         agtop_core::session::SessionState::Idle => ("idle", th::STATE_IDLE),
+        agtop_core::session::SessionState::AwaitingInput => ("input", th::STATE_AWAITING_INPUT),
+        agtop_core::session::SessionState::AwaitingPermission => {
+            ("permit", th::STATE_AWAITING_PERMISSION)
+        }
+        agtop_core::session::SessionState::Stalled => ("stalled", th::STATE_STALLED),
         agtop_core::session::SessionState::Closed => ("closed", th::STATE_CLOSED),
-        _ => ("closed", th::STATE_CLOSED),
+        agtop_core::session::SessionState::Unknown => ("?", th::STATE_UNKNOWN),
+        _ => ("?", th::STATE_UNKNOWN),
     }
 }
 
@@ -71,7 +76,7 @@ mod tests {
     }
 
     #[test]
-    fn live_running_session_displays_running() {
+    fn live_running_session_displays_run() {
         let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 0).unwrap();
         let a = analysis(
             Some(SessionState::Running),
@@ -82,15 +87,15 @@ mod tests {
 
         let (label, style) = display_state(&a, now);
 
-        assert_eq!(label, "running");
+        assert_eq!(label, "run");
         assert_eq!(style, th::STATE_RUNNING);
     }
 
     #[test]
-    fn live_blocked_session_displays_blocked() {
+    fn live_awaiting_permission_session_displays_permit() {
         let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 0).unwrap();
         let a = analysis(
-            Some(SessionState::Blocked),
+            Some(SessionState::AwaitingPermission),
             Some(now),
             Some(42),
             Some(Liveness::Live),
@@ -98,8 +103,8 @@ mod tests {
 
         let (label, style) = display_state(&a, now);
 
-        assert_eq!(label, "blocked");
-        assert_eq!(style, th::STATE_BLOCKED);
+        assert_eq!(label, "permit");
+        assert_eq!(style, th::STATE_AWAITING_PERMISSION);
     }
 
     #[test]

--- a/crates/agtop-cli/src/tui/widgets/state_display.rs
+++ b/crates/agtop-cli/src/tui/widgets/state_display.rs
@@ -11,7 +11,11 @@ pub fn display_state(
         return ("closed", th::STATE_CLOSED);
     }
 
-    match a.summary.state.unwrap_or(agtop_core::session::SessionState::Running) {
+    match a
+        .summary
+        .state
+        .unwrap_or(agtop_core::session::SessionState::Running)
+    {
         agtop_core::session::SessionState::Running => ("running", th::STATE_RUNNING),
         agtop_core::session::SessionState::Blocked => ("blocked", th::STATE_BLOCKED),
         agtop_core::session::SessionState::Idle => ("idle", th::STATE_IDLE),
@@ -69,7 +73,12 @@ mod tests {
     #[test]
     fn live_running_session_displays_running() {
         let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 0).unwrap();
-        let a = analysis(Some(SessionState::Running), Some(now), Some(42), Some(Liveness::Live));
+        let a = analysis(
+            Some(SessionState::Running),
+            Some(now),
+            Some(42),
+            Some(Liveness::Live),
+        );
 
         let (label, style) = display_state(&a, now);
 
@@ -80,7 +89,12 @@ mod tests {
     #[test]
     fn live_blocked_session_displays_blocked() {
         let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 0).unwrap();
-        let a = analysis(Some(SessionState::Blocked), Some(now), Some(42), Some(Liveness::Live));
+        let a = analysis(
+            Some(SessionState::Blocked),
+            Some(now),
+            Some(42),
+            Some(Liveness::Live),
+        );
 
         let (label, style) = display_state(&a, now);
 
@@ -91,7 +105,12 @@ mod tests {
     #[test]
     fn live_idle_session_displays_idle() {
         let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 0).unwrap();
-        let a = analysis(Some(SessionState::Idle), Some(now), Some(42), Some(Liveness::Live));
+        let a = analysis(
+            Some(SessionState::Idle),
+            Some(now),
+            Some(42),
+            Some(Liveness::Live),
+        );
 
         let (label, style) = display_state(&a, now);
 
@@ -113,7 +132,12 @@ mod tests {
     #[test]
     fn stopped_liveness_displays_closed() {
         let now = Utc.with_ymd_and_hms(2026, 4, 19, 12, 0, 0).unwrap();
-        let a = analysis(Some(SessionState::Running), Some(now), Some(42), Some(Liveness::Stopped));
+        let a = analysis(
+            Some(SessionState::Running),
+            Some(now),
+            Some(42),
+            Some(Liveness::Stopped),
+        );
 
         let (label, style) = display_state(&a, now);
 

--- a/crates/agtop-core/src/clients/claude.rs
+++ b/crates/agtop-core/src/clients/claude.rs
@@ -21,7 +21,7 @@ use crate::clients::util::{dir_exists, for_each_jsonl, mtime, parse_ts, Discover
 use crate::error::{Error, Result};
 use crate::pricing::{self, Plan, PlanMode};
 use crate::session::{
-    ClientKind, PlanUsage, PlanWindow, SessionAnalysis, SessionSummary, TokenTotals,
+    ClientKind, PlanUsage, PlanWindow, SessionAnalysis, SessionState, SessionSummary, TokenTotals,
 };
 
 /// Upper bound on how many recent transcripts we scan for synthetic
@@ -248,18 +248,18 @@ fn extract_message_text(v: &serde_json::Value) -> Option<String> {
     }
 }
 
-fn state_from_claude_record(v: &serde_json::Value) -> Option<(String, String)> {
+fn state_from_claude_record(v: &serde_json::Value) -> Option<(SessionState, String)> {
     match v
         .get("message")
         .and_then(|m| m.get("stop_reason"))
         .and_then(|x| x.as_str())
     {
         Some("tool_use") => Some((
-            "waiting".to_string(),
+            SessionState::Running,
             "assistant.stop_reason=tool_use".to_string(),
         )),
         Some("end_turn") => Some((
-            "stopped".to_string(),
+            SessionState::Idle,
             "assistant.stop_reason=end_turn".to_string(),
         )),
         _ => None,
@@ -406,7 +406,7 @@ fn summarize_claude_file(path: &Path) -> Result<SessionSummary> {
     let mut earliest: Option<DateTime<Utc>> = None;
     let mut model: Option<String> = None;
     let mut cwd: Option<String> = None;
-    let mut state: Option<String> = None;
+    let mut state: Option<SessionState> = None;
     let mut state_detail: Option<String> = None;
     let mut session_title: Option<String> = None;
     let mut seen = 0usize;
@@ -830,14 +830,14 @@ mod tests {
     }
 
     #[test]
-    fn assistant_stop_reason_tool_use_maps_to_waiting() {
+    fn assistant_stop_reason_tool_use_maps_to_running() {
         let v = serde_json::json!({
             "message": { "stop_reason": "tool_use" }
         });
         assert_eq!(
             state_from_claude_record(&v),
             Some((
-                "waiting".to_string(),
+                SessionState::Running,
                 "assistant.stop_reason=tool_use".to_string(),
             ))
         );
@@ -1125,7 +1125,7 @@ mod tests {
         assert_eq!(child.session_id, "subagent-child");
         assert_eq!(child.model.as_deref(), Some("claude-3-5-haiku-20241022"));
         assert_eq!(child.cwd.as_deref(), Some("/tmp/subagent"));
-        assert_eq!(child.state.as_deref(), Some("stopped"));
+        assert_eq!(child.state, Some(SessionState::Idle));
         assert_eq!(
             child.state_detail.as_deref(),
             Some("assistant.stop_reason=end_turn")

--- a/crates/agtop-core/src/clients/claude.rs
+++ b/crates/agtop-core/src/clients/claude.rs
@@ -71,6 +71,7 @@ impl Client for ClaudeClient {
             .unwrap_or(self.projects_root.as_path());
         let subscription = read_credentials_plan(claude_dir).1;
         let history_titles = read_history_titles(claude_dir);
+        let runtime_states = read_runtime_states(claude_dir);
         let mut out = Vec::new();
         let projects = match fs::read_dir(&self.projects_root) {
             Ok(r) => r,
@@ -107,6 +108,7 @@ impl Client for ClaudeClient {
                         if s.session_title.is_none() {
                             s.session_title = history_titles.get(&s.session_id).cloned();
                         }
+                        apply_runtime_state(&mut s, &runtime_states);
                         out.push(s)
                     }
                     Ok(_) => continue, // skip empty/abandoned sessions
@@ -225,6 +227,54 @@ fn read_history_titles(claude_dir: &Path) -> HashMap<String, String> {
     out
 }
 
+fn read_runtime_states(claude_dir: &Path) -> HashMap<String, String> {
+    let sessions_dir = claude_dir.join("sessions");
+    let mut out = HashMap::new();
+    let Ok(entries) = fs::read_dir(sessions_dir) else {
+        return out;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().map(|e| e != "json").unwrap_or(true) {
+            continue;
+        }
+        let Ok(bytes) = fs::read(&path) else {
+            continue;
+        };
+        let Ok(v) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+            continue;
+        };
+        if v.get("status").and_then(|x| x.as_str()) != Some("waiting") {
+            continue;
+        }
+        let Some(session_id) = v.get("sessionId").and_then(|x| x.as_str()) else {
+            continue;
+        };
+        let waiting_for = v
+            .get("waitingFor")
+            .and_then(|x| x.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or("unknown");
+        out.insert(session_id.to_string(), waiting_for.to_string());
+    }
+
+    out
+}
+
+fn apply_runtime_state(summary: &mut SessionSummary, runtime_states: &HashMap<String, String>) {
+    let Some(waiting_for) = runtime_states.get(&summary.session_id) else {
+        return;
+    };
+    let state = if waiting_for.starts_with("approve ") {
+        SessionState::AwaitingPermission
+    } else {
+        SessionState::AwaitingInput
+    };
+    summary.state = Some(state);
+    summary.state_detail = Some(format!("claude.runtime.status=waiting:{waiting_for}"));
+}
+
 /// Extract a flat text body from a Claude assistant message record.
 /// Returns `None` if no text parts are present.
 fn extract_message_text(v: &serde_json::Value) -> Option<String> {
@@ -249,6 +299,29 @@ fn extract_message_text(v: &serde_json::Value) -> Option<String> {
 }
 
 fn state_from_claude_record(v: &serde_json::Value) -> Option<(SessionState, String)> {
+    if let Some(content) = v
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|x| x.as_array())
+    {
+        for part in content {
+            if part.get("type").and_then(|x| x.as_str()) == Some("permission_request") {
+                return Some((
+                    SessionState::AwaitingPermission,
+                    "assistant.content=permission_request".to_string(),
+                ));
+            }
+            if part.get("type").and_then(|x| x.as_str()) == Some("tool_use")
+                && part.get("name").and_then(|x| x.as_str()) == Some("AskUserQuestion")
+            {
+                return Some((
+                    SessionState::AwaitingInput,
+                    "assistant.tool_use=AskUserQuestion".to_string(),
+                ));
+            }
+        }
+    }
+
     match v
         .get("message")
         .and_then(|m| m.get("stop_reason"))
@@ -840,6 +913,84 @@ mod tests {
                 SessionState::Running,
                 "assistant.stop_reason=tool_use".to_string(),
             ))
+        );
+    }
+
+    #[test]
+    fn assistant_ask_user_question_tool_use_maps_to_awaiting_input() {
+        let v = serde_json::json!({
+            "message": {
+                "stop_reason": "tool_use",
+                "content": [{
+                    "type": "tool_use",
+                    "name": "AskUserQuestion"
+                }]
+            }
+        });
+
+        assert_eq!(
+            state_from_claude_record(&v),
+            Some((
+                SessionState::AwaitingInput,
+                "assistant.tool_use=AskUserQuestion".to_string(),
+            ))
+        );
+    }
+
+    #[test]
+    fn assistant_permission_request_part_maps_to_awaiting_permission() {
+        let v = serde_json::json!({
+            "message": {
+                "stop_reason": "tool_use",
+                "content": [{"type": "permission_request"}]
+            }
+        });
+
+        assert_eq!(
+            state_from_claude_record(&v),
+            Some((
+                SessionState::AwaitingPermission,
+                "assistant.content=permission_request".to_string(),
+            ))
+        );
+    }
+
+    #[test]
+    fn list_sessions_maps_waiting_runtime_metadata_to_blocked() {
+        let (_td, projects_root) = make_fake_claude_home();
+        let claude_dir = projects_root.parent().unwrap();
+        let session_id = "02742fb3-d98e-4fa2-8184-2fddd7ee544d";
+        let transcript = projects_root
+            .join("proj")
+            .join(format!("{session_id}.jsonl"));
+        write_jsonl(
+            &transcript,
+            &[
+                r#"{"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"model":"claude-opus-4","content":[{"type":"tool_use","name":"Write"}],"stop_reason":"tool_use"}}"#,
+            ],
+        );
+        let sessions_dir = claude_dir.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let mut f = fs::File::create(sessions_dir.join("123.json")).unwrap();
+        f.write_all(
+            format!(
+                r#"{{"pid":123,"sessionId":"{session_id}","status":"waiting","waitingFor":"approve Write"}}"#
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+
+        let client = ClaudeClient {
+            projects_root,
+            discover_cache: std::sync::Mutex::default(),
+        };
+
+        let sessions = client.list_sessions().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].state, Some(SessionState::AwaitingPermission));
+        assert_eq!(
+            sessions[0].state_detail.as_deref(),
+            Some("claude.runtime.status=waiting:approve Write")
         );
     }
 

--- a/crates/agtop-core/src/clients/codex.rs
+++ b/crates/agtop-core/src/clients/codex.rs
@@ -311,18 +311,45 @@ fn effort_from_turn_context(payload: &serde_json::Value) -> Option<(String, Stri
 
 fn state_from_response_item(payload: &serde_json::Value) -> Option<(SessionState, String)> {
     match payload.get("type").and_then(|x| x.as_str()) {
-        Some("function_call") | Some("custom_tool_call") => Some((
-            SessionState::Running,
-            format!(
-                "response_item:{}",
-                payload
-                    .get("type")
-                    .and_then(|x| x.as_str())
-                    .unwrap_or("call")
-            ),
-        )),
+        Some("function_call") | Some("custom_tool_call") => {
+            let ty = payload
+                .get("type")
+                .and_then(|x| x.as_str())
+                .unwrap_or("call");
+            if codex_call_requires_escalation(payload) {
+                Some((
+                    SessionState::AwaitingPermission,
+                    format!("response_item:{ty}:require_escalated"),
+                ))
+            } else {
+                Some((SessionState::Running, format!("response_item:{ty}")))
+            }
+        }
         _ => None,
     }
+}
+
+fn codex_call_requires_escalation(payload: &serde_json::Value) -> bool {
+    let Some(arguments) = payload.get("arguments") else {
+        return false;
+    };
+    if arguments
+        .get("sandbox_permissions")
+        .and_then(|x| x.as_str())
+        == Some("require_escalated")
+    {
+        return true;
+    }
+    arguments
+        .as_str()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+        .and_then(|v| {
+            v.get("sandbox_permissions")
+                .and_then(|x| x.as_str())
+                .map(str::to_string)
+        })
+        .as_deref()
+        == Some("require_escalated")
 }
 
 fn text_from_codex_content(content: &serde_json::Value) -> Option<String> {
@@ -367,13 +394,7 @@ fn state_from_codex_message(payload: &serde_json::Value) -> Option<(SessionState
         return None;
     }
     let phase = payload.get("phase").and_then(|x| x.as_str());
-    let text = message_text_from_payload(payload).unwrap_or_default();
-    if phase == Some("final_answer") && text.contains('?') {
-        Some((
-            SessionState::Blocked,
-            "response_item:assistant-question".to_string(),
-        ))
-    } else if phase == Some("final_answer") {
+    if phase == Some("final_answer") {
         Some((
             SessionState::Idle,
             "response_item:assistant-final".to_string(),
@@ -993,6 +1014,41 @@ mod tests {
     #[test]
     fn base64url_decode_rejects_garbage() {
         assert!(base64url_decode("!!!").is_none());
+    }
+
+    #[test]
+    fn response_item_escalated_function_call_maps_to_awaiting_permission() {
+        let payload = serde_json::json!({
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": r#"{"cmd":"cp /tmp/joke.txt /home/joke.txt","sandbox_permissions":"require_escalated","justification":"Allow writing outside workspace?"}"#,
+        });
+
+        assert_eq!(
+            state_from_response_item(&payload),
+            Some((
+                SessionState::AwaitingPermission,
+                "response_item:function_call:require_escalated".to_string(),
+            ))
+        );
+    }
+
+    #[test]
+    fn final_answer_question_text_alone_does_not_map_to_blocked() {
+        let payload = serde_json::json!({
+            "type": "message",
+            "role": "assistant",
+            "phase": "final_answer",
+            "content": [{"type": "output_text", "text": "Do you want me to continue?"}],
+        });
+
+        assert_eq!(
+            state_from_codex_message(&payload),
+            Some((
+                SessionState::Idle,
+                "response_item:assistant-final".to_string(),
+            ))
+        );
     }
 
     // --- plan_usage end-to-end tests ---

--- a/crates/agtop-core/src/clients/codex.rs
+++ b/crates/agtop-core/src/clients/codex.rs
@@ -24,7 +24,7 @@ use crate::clients::util::{dir_exists, for_each_jsonl, mtime, parse_ts, Discover
 use crate::error::{Error, Result};
 use crate::pricing::{self, Plan, PlanMode};
 use crate::session::{
-    ClientKind, PlanUsage, PlanWindow, SessionAnalysis, SessionSummary, TokenTotals,
+    ClientKind, PlanUsage, PlanWindow, SessionAnalysis, SessionState, SessionSummary, TokenTotals,
 };
 
 /// Number of most-recently-modified rollout files to scan when looking
@@ -309,10 +309,10 @@ fn effort_from_turn_context(payload: &serde_json::Value) -> Option<(String, Stri
         })
 }
 
-fn state_from_response_item(payload: &serde_json::Value) -> Option<(String, String)> {
+fn state_from_response_item(payload: &serde_json::Value) -> Option<(SessionState, String)> {
     match payload.get("type").and_then(|x| x.as_str()) {
         Some("function_call") | Some("custom_tool_call") => Some((
-            "waiting".to_string(),
+            SessionState::Running,
             format!(
                 "response_item:{}",
                 payload
@@ -362,7 +362,7 @@ fn message_text_from_payload(payload: &serde_json::Value) -> Option<String> {
         })
 }
 
-fn state_from_codex_message(payload: &serde_json::Value) -> Option<(String, String)> {
+fn state_from_codex_message(payload: &serde_json::Value) -> Option<(SessionState, String)> {
     if payload.get("role").and_then(|x| x.as_str()) != Some("assistant") {
         return None;
     }
@@ -370,12 +370,12 @@ fn state_from_codex_message(payload: &serde_json::Value) -> Option<(String, Stri
     let text = message_text_from_payload(payload).unwrap_or_default();
     if phase == Some("final_answer") && text.contains('?') {
         Some((
-            "waiting".to_string(),
+            SessionState::Blocked,
             "response_item:assistant-question".to_string(),
         ))
     } else if phase == Some("final_answer") {
         Some((
-            "stopped".to_string(),
+            SessionState::Idle,
             "response_item:assistant-final".to_string(),
         ))
     } else {
@@ -590,7 +590,7 @@ fn summarize_codex_file(path: &Path) -> Result<SessionSummary> {
     let mut cwd: Option<String> = None;
     let mut model_effort: Option<String> = None;
     let mut model_effort_detail: Option<String> = None;
-    let mut state: Option<String> = None;
+    let mut state: Option<SessionState> = None;
     let mut state_detail: Option<String> = None;
     let mut session_title: Option<String> = None;
     // `thread_name_updated` is the authoritative AI-generated title; once set
@@ -662,7 +662,7 @@ fn summarize_codex_file(path: &Path) -> Result<SessionSummary> {
                         // clears any prior "waiting" state — the tool call completed.
                         let ty = p.get("type").and_then(|x| x.as_str()).unwrap_or("");
                         if matches!(ty, "function_call_output" | "custom_tool_call_output") {
-                            state = Some("stopped".to_string());
+                            state = Some(SessionState::Idle);
                             state_detail = Some("response_item:tool-output".to_string());
                         }
                     }

--- a/crates/agtop-core/src/clients/copilot.rs
+++ b/crates/agtop-core/src/clients/copilot.rs
@@ -414,7 +414,7 @@ fn parse_session_jsonl_all(
         None,
         path.to_path_buf(),
         if waiting {
-            Some(SessionState::Blocked)
+            Some(SessionState::AwaitingInput)
         } else {
             None
         },

--- a/crates/agtop-core/src/clients/copilot.rs
+++ b/crates/agtop-core/src/clients/copilot.rs
@@ -21,7 +21,8 @@ use crate::clients::util::{for_each_jsonl, mtime, DiscoverCache};
 use crate::error::Result;
 use crate::pricing::Plan;
 use crate::session::{
-    ClientKind, CostBreakdown, PlanUsage, PlanWindow, SessionAnalysis, SessionSummary, TokenTotals,
+    ClientKind, CostBreakdown, PlanUsage, PlanWindow, SessionAnalysis, SessionState, SessionSummary,
+    TokenTotals,
 };
 
 /// Quota API cache TTL.
@@ -413,7 +414,7 @@ fn parse_session_jsonl_all(
         None,
         path.to_path_buf(),
         if waiting {
-            Some("waiting".into())
+            Some(SessionState::Blocked)
         } else {
             None
         },

--- a/crates/agtop-core/src/clients/copilot.rs
+++ b/crates/agtop-core/src/clients/copilot.rs
@@ -21,8 +21,8 @@ use crate::clients::util::{for_each_jsonl, mtime, DiscoverCache};
 use crate::error::Result;
 use crate::pricing::Plan;
 use crate::session::{
-    ClientKind, CostBreakdown, PlanUsage, PlanWindow, SessionAnalysis, SessionState, SessionSummary,
-    TokenTotals,
+    ClientKind, CostBreakdown, PlanUsage, PlanWindow, SessionAnalysis, SessionState,
+    SessionSummary, TokenTotals,
 };
 
 /// Quota API cache TTL.

--- a/crates/agtop-core/src/clients/gemini_cli.rs
+++ b/crates/agtop-core/src/clients/gemini_cli.rs
@@ -17,7 +17,9 @@ use crate::client::Client;
 use crate::clients::util::{dir_exists, for_each_jsonl, mtime, parse_ts, DiscoverCache};
 use crate::error::Result;
 use crate::pricing::{self, Plan, PlanMode};
-use crate::session::{ClientKind, CostBreakdown, SessionAnalysis, SessionSummary, TokenTotals};
+use crate::session::{
+    ClientKind, CostBreakdown, SessionAnalysis, SessionState, SessionSummary, TokenTotals,
+};
 
 #[derive(Debug)]
 pub struct GeminiCliClient {
@@ -376,7 +378,7 @@ fn parse_gemini_session(
     let mut last_updated: Option<DateTime<Utc>> = None;
     let mut model = global_model;
     let mut session_title: Option<String> = None;
-    let mut state: Option<String> = None;
+    let mut state: Option<SessionState> = None;
     let mut state_detail: Option<String> = None;
     let mut seen = 0usize;
 
@@ -492,7 +494,7 @@ fn parse_gemini_session_json(
         })
         .or(global_model);
 
-    let mut state: Option<String> = None;
+    let mut state: Option<SessionState> = None;
     let mut state_detail: Option<String> = None;
     if let Some(messages) = v.get("messages").and_then(|messages| messages.as_array()) {
         for message in messages {
@@ -536,7 +538,7 @@ fn parse_gemini_session_json(
 
 fn update_state_from_gemini_message(
     message: &serde_json::Value,
-    state: &mut Option<String>,
+    state: &mut Option<SessionState>,
     state_detail: &mut Option<String>,
 ) {
     if let Some(tool_calls) = gemini_tool_calls(message) {
@@ -544,14 +546,14 @@ fn update_state_from_gemini_message(
             .iter()
             .any(|call| call.get("status").and_then(|x| x.as_str()) != Some("success"))
         {
-            *state = Some("waiting".to_string());
+            *state = Some(SessionState::Running);
             *state_detail = Some("gemini.toolCalls.pending_or_error".to_string());
         } else if !tool_calls.is_empty() {
-            *state = Some("stopped".to_string());
+            *state = Some(SessionState::Idle);
             *state_detail = Some("gemini.toolCalls.success".to_string());
         }
     } else {
-        *state = Some("stopped".to_string());
+        *state = Some(SessionState::Idle);
         *state_detail = Some("gemini.message".to_string());
     }
 }

--- a/crates/agtop-core/src/clients/opencode.rs
+++ b/crates/agtop-core/src/clients/opencode.rs
@@ -102,6 +102,32 @@ impl Client for OpenCodeClient {
                 .retain_paths(&live_paths);
         }
 
+        // Apply pending permission requests to Running OpenCode sessions whose
+        // state_detail contains a running tool call.  The stub returns an empty
+        // list, so this is currently a no-op; future live-server integration
+        // replaces pending_opencode_permission_requests() with real data.
+        let permission_requests = pending_opencode_permission_requests();
+        if !permission_requests.is_empty() {
+            for summary in out.iter_mut() {
+                if summary.state != Some(SessionState::Running) {
+                    continue;
+                }
+                let (msg_id, call_id) = match summary.state_detail.as_deref() {
+                    Some(d) if d.contains("opencode.tool=") => (
+                        parse_detail_message_id(d).map(str::to_string),
+                        parse_detail_call_id(d).map(str::to_string),
+                    ),
+                    _ => continue,
+                };
+                apply_opencode_permission_requests(
+                    summary,
+                    &permission_requests,
+                    msg_id.as_deref(),
+                    call_id.as_deref(),
+                );
+            }
+        }
+
         Ok(out)
     }
 
@@ -174,6 +200,36 @@ fn state_from_opencode_message(v: &serde_json::Value) -> Option<(SessionState, S
     }
 }
 
+fn state_from_opencode_part(v: &serde_json::Value) -> Option<(SessionState, String)> {
+    if v.get("type").and_then(|x| x.as_str()) != Some("tool")
+        || v.pointer("/state/status").and_then(|x| x.as_str()) != Some("running")
+    {
+        return None;
+    }
+
+    let tool = v.get("tool").and_then(|x| x.as_str())?;
+    if tool == "question" {
+        return Some((
+            SessionState::AwaitingInput,
+            format!("opencode.tool={tool}:running"),
+        ));
+    }
+    if matches!(tool, "write" | "edit" | "bash" | "task") {
+        return Some((
+            SessionState::Running,
+            format!("opencode.tool={tool}:running"),
+        ));
+    }
+    None
+}
+
+/// Returns the call ID embedded in a running tool part, if present.
+fn call_id_from_part(v: &serde_json::Value) -> Option<&str> {
+    v.get("callID")
+        .or_else(|| v.get("id"))
+        .and_then(|x| x.as_str())
+}
+
 fn is_opencode_pending_placeholder(v: &serde_json::Value) -> bool {
     if v.get("finish").is_some() {
         return false;
@@ -212,6 +268,58 @@ fn is_opencode_pending_placeholder(v: &serde_json::Value) -> bool {
 fn read_json(path: &Path) -> Result<serde_json::Value> {
     let text = fs::read_to_string(path)?;
     Ok(serde_json::from_str(&text)?)
+}
+
+// ---------------------------------------------------------------------------
+// Permission request matching
+// ---------------------------------------------------------------------------
+
+/// Returns pending OpenCode permission requests from a live source.
+///
+/// This is a stub that always returns an empty list.  In the future it may
+/// query the running OpenCode server's permission-request endpoint.  The
+/// empty return value is intentional: it prevents generic running tool parts
+/// (write/edit/bash/task) from being incorrectly promoted to
+/// `AwaitingPermission` without an explicit, correlated permission request.
+fn pending_opencode_permission_requests() -> Vec<serde_json::Value> {
+    Vec::new()
+}
+
+/// Applies pending OpenCode permission requests to a session summary.
+///
+/// A request matches when its `sessionID` equals `summary.session_id` **and**
+/// its `tool.messageID` / `tool.callID` match the IDs embedded in the current
+/// `state_detail` (extracted via `latest_message_id` / `latest_call_id`).
+/// When a match is found the summary state is promoted to `AwaitingPermission`.
+fn apply_opencode_permission_requests(
+    summary: &mut SessionSummary,
+    requests: &[serde_json::Value],
+    latest_message_id: Option<&str>,
+    latest_call_id: Option<&str>,
+) {
+    let matched = requests.iter().any(|request| {
+        request.get("sessionID").and_then(|v| v.as_str()) == Some(summary.session_id.as_str())
+            && request.pointer("/tool/messageID").and_then(|v| v.as_str()) == latest_message_id
+            && request.pointer("/tool/callID").and_then(|v| v.as_str()) == latest_call_id
+    });
+    if matched {
+        summary.state = Some(SessionState::AwaitingPermission);
+        summary.state_detail = Some("opencode.permission=pending".to_string());
+    }
+}
+
+/// Parse `message=<id>` from a state detail string.
+fn parse_detail_message_id(detail: &str) -> Option<&str> {
+    detail
+        .split_whitespace()
+        .find_map(|tok| tok.strip_prefix("message="))
+}
+
+/// Parse `call=<id>` from a state detail string.
+fn parse_detail_call_id(detail: &str) -> Option<&str> {
+    detail
+        .split_whitespace()
+        .find_map(|tok| tok.strip_prefix("call="))
 }
 
 // ---------------------------------------------------------------------------
@@ -1177,37 +1285,80 @@ fn latest_message_state_sqlite(
     // Only inspect the most recent *assistant* message for state.
     // User messages (tool results, question responses) do not carry a
     // `finish` field and would otherwise mask the actual assistant state.
-    let rows: Vec<String> = match conn
+    let rows: Vec<(String, String)> = match conn
         .prepare(
-            "SELECT data FROM message \
+            "SELECT id, data FROM message \
              WHERE session_id = ?1 \
-               AND json_extract(data, '$.role') = 'assistant' \
-             ORDER BY time_created DESC LIMIT 2",
+                AND json_extract(data, '$.role') = 'assistant' \
+              ORDER BY time_created DESC LIMIT 2",
         )
         .and_then(|mut stmt| {
-            stmt.query_map(rusqlite::params![session_id], |row| row.get::<_, String>(0))
-                .map(|rows| rows.filter_map(|r| r.ok()).collect())
+            stmt.query_map(rusqlite::params![session_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map(|rows| rows.filter_map(|r| r.ok()).collect())
         }) {
         Ok(rows) => rows,
         Err(_) => return (None, None),
     };
 
-    let mut parsed = rows
-        .iter()
-        .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok());
+    let mut parsed = rows.iter().filter_map(|(id, data)| {
+        serde_json::from_str::<serde_json::Value>(data)
+            .ok()
+            .map(|value| (id.as_str(), value))
+    });
 
-    let Some(latest) = parsed.next() else {
+    let Some((latest_id, latest)) = parsed.next() else {
         return (None, None);
     };
+    if let Some((state, detail)) = latest_message_part_state_sqlite(conn, latest_id, session_id) {
+        return (Some(state), Some(detail));
+    }
     if is_opencode_pending_placeholder(&latest) {
         return parsed
             .next()
-            .and_then(|value| state_from_opencode_message(&value))
+            .and_then(|(_, value)| state_from_opencode_message(&value))
             .map_or((None, None), |(state, detail)| (Some(state), Some(detail)));
     }
 
     state_from_opencode_message(&latest)
         .map_or((None, None), |(state, detail)| (Some(state), Some(detail)))
+}
+
+fn latest_message_part_state_sqlite(
+    conn: &rusqlite::Connection,
+    message_id: &str,
+    session_id: &str,
+) -> Option<(SessionState, String)> {
+    let rows: Vec<String> = conn
+        .prepare(
+            "SELECT data FROM part \
+             WHERE session_id = ?1 AND message_id = ?2 \
+             ORDER BY time_created DESC",
+        )
+        .ok()?
+        .query_map(rusqlite::params![session_id, message_id], |row| {
+            row.get::<_, String>(0)
+        })
+        .ok()?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    rows.iter()
+        .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+        .find_map(|value| {
+            let (state, base_detail) = state_from_opencode_part(&value)?;
+            // For running tool parts, embed message/call IDs so the
+            // permission-request matcher can correlate against live requests.
+            let call_id = call_id_from_part(&value);
+            let detail = match call_id {
+                Some(cid) => {
+                    format!("{base_detail} message={message_id} call={cid}")
+                }
+                None => format!("{base_detail} message={message_id}"),
+            };
+            Some((state, detail))
+        })
 }
 
 fn first_message_identity_sqlite(
@@ -2565,5 +2716,178 @@ mod tests {
 
         let got = resolve_subscription(&subscriptions, None, Some("openai/gpt-5.4"));
         assert_eq!(got.as_deref(), Some("ChatGPT Plus"));
+    }
+
+    #[test]
+    fn latest_message_state_sqlite_maps_running_question_part_to_awaiting_input() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "CREATE TABLE part (
+                id TEXT PRIMARY KEY,
+                message_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            )",
+            [],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![
+                "msg_question",
+                "ses_test",
+                10i64,
+                10i64,
+                serde_json::json!({
+                    "role": "assistant",
+                    "tokens": {"input": 0, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}}
+                })
+                .to_string()
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![
+                "prt_question",
+                "msg_question",
+                "ses_test",
+                11i64,
+                11i64,
+                serde_json::json!({
+                    "type": "tool",
+                    "tool": "question",
+                    "state": {"status": "running"}
+                })
+                .to_string()
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            latest_message_state_sqlite(&conn, "ses_test"),
+            (
+                Some(SessionState::AwaitingInput),
+                Some("opencode.tool=question:running message=msg_question".to_string()),
+            )
+        );
+    }
+
+    #[test]
+    fn latest_message_state_sqlite_keeps_running_write_part_running() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "CREATE TABLE part (
+                id TEXT PRIMARY KEY,
+                message_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            )",
+            [],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![
+                "msg_write",
+                "ses_test",
+                10i64,
+                10i64,
+                serde_json::json!({
+                    "role": "assistant",
+                    "tokens": {"input": 0, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}}
+                })
+                .to_string()
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![
+                "prt_write",
+                "msg_write",
+                "ses_test",
+                11i64,
+                11i64,
+                serde_json::json!({
+                    "type": "tool",
+                    "tool": "write",
+                    "state": {"status": "running", "input": {"filePath": "/etc/joke.txt"}}
+                })
+                .to_string()
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            latest_message_state_sqlite(&conn, "ses_test"),
+            (
+                Some(SessionState::Running),
+                Some("opencode.tool=write:running message=msg_write".to_string()),
+            )
+        );
+    }
+
+    #[test]
+    fn opencode_permission_request_maps_matching_tool_to_awaiting_permission() {
+        let mut summary = SessionSummary::new(
+            ClientKind::OpenCode,
+            None,
+            "ses_test".to_string(),
+            None,
+            None,
+            None,
+            None,
+            PathBuf::from("/tmp/opencode.db"),
+            Some(SessionState::Running),
+            Some("opencode.tool=write:running message=msg1 call=call1".to_string()),
+            None,
+            None,
+        );
+        let requests = vec![serde_json::json!({
+            "sessionID": "ses_test",
+            "permission": "edit",
+            "tool": {"messageID": "msg1", "callID": "call1"}
+        })];
+
+        apply_opencode_permission_requests(&mut summary, &requests, Some("msg1"), Some("call1"));
+
+        assert_eq!(summary.state, Some(SessionState::AwaitingPermission));
+        assert_eq!(
+            summary.state_detail.as_deref(),
+            Some("opencode.permission=pending")
+        );
     }
 }

--- a/crates/agtop-core/src/clients/opencode.rs
+++ b/crates/agtop-core/src/clients/opencode.rs
@@ -25,7 +25,7 @@ use crate::clients::util::{dir_exists, DiscoverCache};
 use crate::error::{Error, Result};
 use crate::pricing::{self, Plan, PlanMode};
 use crate::session::{
-    ClientKind, PlanUsage, PlanWindow, SessionAnalysis, SessionSummary, TokenTotals,
+    ClientKind, PlanUsage, PlanWindow, SessionAnalysis, SessionState, SessionSummary, TokenTotals,
 };
 
 const LIVE_USAGE_TIMEOUT: Duration = Duration::from_secs(15);
@@ -166,10 +166,10 @@ fn ms_to_utc(ms: i64) -> Option<DateTime<Utc>> {
     Utc.timestamp_millis_opt(ms).single()
 }
 
-fn state_from_opencode_message(v: &serde_json::Value) -> Option<(String, String)> {
+fn state_from_opencode_message(v: &serde_json::Value) -> Option<(SessionState, String)> {
     match v.get("finish").and_then(|x| x.as_str()) {
-        Some("tool-calls") => Some(("waiting".to_string(), "finish=tool-calls".to_string())),
-        Some("stop") => Some(("stopped".to_string(), "finish=stop".to_string())),
+        Some("tool-calls") => Some((SessionState::Running, "finish=tool-calls".to_string())),
+        Some("stop") => Some((SessionState::Idle, "finish=stop".to_string())),
         _ => None,
     }
 }
@@ -1173,7 +1173,7 @@ fn list_child_sessions_sqlite(
 fn latest_message_state_sqlite(
     conn: &rusqlite::Connection,
     session_id: &str,
-) -> (Option<String>, Option<String>) {
+) -> (Option<SessionState>, Option<String>) {
     // Only inspect the most recent *assistant* message for state.
     // User messages (tool results, question responses) do not carry a
     // `finish` field and would otherwise mask the actual assistant state.
@@ -1574,7 +1574,7 @@ fn summarize_opencode_session_json(
     })
 }
 
-fn latest_message_state_json(msg_dir: &Path) -> (Option<String>, Option<String>) {
+fn latest_message_state_json(msg_dir: &Path) -> (Option<SessionState>, Option<String>) {
     if !dir_exists(msg_dir) {
         return (None, None);
     }
@@ -2189,11 +2189,11 @@ mod tests {
     }
 
     #[test]
-    fn finish_tool_calls_maps_to_waiting() {
+    fn finish_tool_calls_maps_to_running() {
         let v = serde_json::json!({ "finish": "tool-calls" });
         assert_eq!(
             state_from_opencode_message(&v),
-            Some(("waiting".to_string(), "finish=tool-calls".to_string()))
+            Some((SessionState::Running, "finish=tool-calls".to_string()))
         );
     }
 

--- a/crates/agtop-core/src/lib.rs
+++ b/crates/agtop-core/src/lib.rs
@@ -30,7 +30,8 @@ pub use error::{Error, Result};
 pub use pricing::{Plan, PlanMode, Rates};
 pub use process::{Confidence, Liveness, ProcessCorrelator, ProcessInfo};
 pub use session::{
-    ClientKind, CostBreakdown, PlanUsage, PlanWindow, SessionAnalysis, SessionSummary, TokenTotals,
+    ClientKind, CostBreakdown, PlanUsage, PlanWindow, SessionAnalysis, SessionState,
+    SessionSummary, TokenTotals,
 };
 
 use std::sync::Arc;

--- a/crates/agtop-core/src/lib.rs
+++ b/crates/agtop-core/src/lib.rs
@@ -22,6 +22,8 @@ pub mod process;
 pub mod project;
 pub mod quota;
 pub mod session;
+pub mod state_resolution;
+pub use state_resolution::resolve_session_states;
 
 // Flat re-exports for the most commonly used public API items.
 // Consumers may also access sub-modules directly (e.g. `agtop_core::pricing::lookup`).

--- a/crates/agtop-core/src/session.rs
+++ b/crates/agtop-core/src/session.rs
@@ -54,29 +54,53 @@ impl std::fmt::Display for ClientKind {
     }
 }
 
-/// Coarse session activity state.
+/// Live-aware session activity state.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionState {
-    /// Agent process is doing work. Tool calls and tool responses are running.
+    /// Live session is actively doing work or has active child work.
     Running,
-    /// Agent process explicitly requires user action.
-    Blocked,
-    /// Agent process is alive but has finished the current work/turn.
+    /// Live session has completed the current turn and is ready for input.
     Idle,
-    /// No agent process is associated with the session.
+    /// Live session is explicitly waiting for a user answer or choice.
+    AwaitingInput,
+    /// Live session is explicitly waiting for tool/sandbox/filesystem approval.
+    AwaitingPermission,
+    /// Live in-progress session has no observable progress past the threshold.
+    Stalled,
+    /// No live process/runtime association exists for this session.
     Closed,
+    /// Evidence is missing, unsupported, or contradictory.
+    Unknown,
 }
 
 impl SessionState {
+    /// Returns the canonical snake_case string representation (matches serde serialization).
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Running => "running",
-            Self::Blocked => "blocked",
             Self::Idle => "idle",
+            Self::AwaitingInput => "awaiting_input",
+            Self::AwaitingPermission => "awaiting_permission",
+            Self::Stalled => "stalled",
             Self::Closed => "closed",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Returns a short display label suitable for constrained-width UIs (e.g. TUI columns).
+    #[must_use]
+    pub const fn compact_label(self) -> &'static str {
+        match self {
+            Self::Running => "run",
+            Self::Idle => "idle",
+            Self::AwaitingInput => "input",
+            Self::AwaitingPermission => "permit",
+            Self::Stalled => "stalled",
+            Self::Closed => "closed",
+            Self::Unknown => "?",
         }
     }
 }
@@ -469,34 +493,10 @@ mod tests {
     }
 
     #[test]
-    fn session_state_serializes_to_lowercase_labels() {
-        assert_eq!(
-            serde_json::to_value(SessionState::Running).unwrap(),
-            json!("running")
-        );
-        assert_eq!(
-            serde_json::to_value(SessionState::Blocked).unwrap(),
-            json!("blocked")
-        );
-        assert_eq!(
-            serde_json::to_value(SessionState::Idle).unwrap(),
-            json!("idle")
-        );
-        assert_eq!(
-            serde_json::to_value(SessionState::Closed).unwrap(),
-            json!("closed")
-        );
-    }
-
-    #[test]
     fn session_state_deserializes_lowercase_labels() {
         assert_eq!(
             serde_json::from_value::<SessionState>(json!("running")).unwrap(),
             SessionState::Running
-        );
-        assert_eq!(
-            serde_json::from_value::<SessionState>(json!("blocked")).unwrap(),
-            SessionState::Blocked
         );
         assert_eq!(
             serde_json::from_value::<SessionState>(json!("idle")).unwrap(),
@@ -506,5 +506,54 @@ mod tests {
             serde_json::from_value::<SessionState>(json!("closed")).unwrap(),
             SessionState::Closed
         );
+    }
+}
+
+#[cfg(test)]
+mod session_state_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn session_state_serializes_to_stable_json_labels() {
+        assert_eq!(
+            serde_json::to_value(SessionState::Running).unwrap(),
+            json!("running")
+        );
+        assert_eq!(
+            serde_json::to_value(SessionState::Idle).unwrap(),
+            json!("idle")
+        );
+        assert_eq!(
+            serde_json::to_value(SessionState::AwaitingInput).unwrap(),
+            json!("awaiting_input")
+        );
+        assert_eq!(
+            serde_json::to_value(SessionState::AwaitingPermission).unwrap(),
+            json!("awaiting_permission")
+        );
+        assert_eq!(
+            serde_json::to_value(SessionState::Stalled).unwrap(),
+            json!("stalled")
+        );
+        assert_eq!(
+            serde_json::to_value(SessionState::Closed).unwrap(),
+            json!("closed")
+        );
+        assert_eq!(
+            serde_json::to_value(SessionState::Unknown).unwrap(),
+            json!("unknown")
+        );
+    }
+
+    #[test]
+    fn session_state_has_stable_compact_labels() {
+        assert_eq!(SessionState::Running.compact_label(), "run");
+        assert_eq!(SessionState::Idle.compact_label(), "idle");
+        assert_eq!(SessionState::AwaitingInput.compact_label(), "input");
+        assert_eq!(SessionState::AwaitingPermission.compact_label(), "permit");
+        assert_eq!(SessionState::Stalled.compact_label(), "stalled");
+        assert_eq!(SessionState::Closed.compact_label(), "closed");
+        assert_eq!(SessionState::Unknown.compact_label(), "?");
     }
 }

--- a/crates/agtop-core/src/session.rs
+++ b/crates/agtop-core/src/session.rs
@@ -54,6 +54,32 @@ impl std::fmt::Display for ClientKind {
     }
 }
 
+/// Coarse session activity state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionState {
+    /// Agent process is doing work. Tool calls and tool responses are running.
+    Running,
+    /// Agent process explicitly requires user action.
+    Blocked,
+    /// Agent process is alive but has finished the current work/turn.
+    Idle,
+    /// No agent process is associated with the session.
+    Closed,
+}
+
+impl SessionState {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Blocked => "blocked",
+            Self::Idle => "idle",
+            Self::Closed => "closed",
+        }
+    }
+}
+
 /// Lightweight session metadata derived from file headers/names.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -70,9 +96,9 @@ pub struct SessionSummary {
     pub model: Option<String>,
     /// Working directory (best-effort). Used for display labels.
     pub cwd: Option<String>,
-    /// Coarse workflow state such as `waiting` or `stopped`.
+    /// Coarse session activity state.
     #[serde(default)]
-    pub state: Option<String>,
+    pub state: Option<SessionState>,
     /// Client-specific explanation of the derived state.
     #[serde(default)]
     pub state_detail: Option<String>,
@@ -124,7 +150,7 @@ impl SessionSummary {
         model: Option<String>,
         cwd: Option<String>,
         data_path: std::path::PathBuf,
-        state: Option<String>,
+        state: Option<SessionState>,
         state_detail: Option<String>,
         model_effort: Option<String>,
         model_effort_detail: Option<String>,
@@ -433,5 +459,33 @@ mod tests {
         let usage: PlanUsage = serde_json::from_value(raw).expect("deserialize legacy plan usage");
         assert_eq!(usage.client, ClientKind::Codex);
         assert_eq!(usage.plan_name.as_deref(), Some("plus"));
+    }
+
+    #[test]
+    fn session_state_serializes_to_lowercase_labels() {
+        assert_eq!(serde_json::to_value(SessionState::Running).unwrap(), json!("running"));
+        assert_eq!(serde_json::to_value(SessionState::Blocked).unwrap(), json!("blocked"));
+        assert_eq!(serde_json::to_value(SessionState::Idle).unwrap(), json!("idle"));
+        assert_eq!(serde_json::to_value(SessionState::Closed).unwrap(), json!("closed"));
+    }
+
+    #[test]
+    fn session_state_deserializes_lowercase_labels() {
+        assert_eq!(
+            serde_json::from_value::<SessionState>(json!("running")).unwrap(),
+            SessionState::Running
+        );
+        assert_eq!(
+            serde_json::from_value::<SessionState>(json!("blocked")).unwrap(),
+            SessionState::Blocked
+        );
+        assert_eq!(
+            serde_json::from_value::<SessionState>(json!("idle")).unwrap(),
+            SessionState::Idle
+        );
+        assert_eq!(
+            serde_json::from_value::<SessionState>(json!("closed")).unwrap(),
+            SessionState::Closed
+        );
     }
 }

--- a/crates/agtop-core/src/session.rs
+++ b/crates/agtop-core/src/session.rs
@@ -55,6 +55,7 @@ impl std::fmt::Display for ClientKind {
 }
 
 /// Coarse session activity state.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionState {
@@ -77,6 +78,12 @@ impl SessionState {
             Self::Idle => "idle",
             Self::Closed => "closed",
         }
+    }
+}
+
+impl std::fmt::Display for SessionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/agtop-core/src/session.rs
+++ b/crates/agtop-core/src/session.rs
@@ -470,10 +470,22 @@ mod tests {
 
     #[test]
     fn session_state_serializes_to_lowercase_labels() {
-        assert_eq!(serde_json::to_value(SessionState::Running).unwrap(), json!("running"));
-        assert_eq!(serde_json::to_value(SessionState::Blocked).unwrap(), json!("blocked"));
-        assert_eq!(serde_json::to_value(SessionState::Idle).unwrap(), json!("idle"));
-        assert_eq!(serde_json::to_value(SessionState::Closed).unwrap(), json!("closed"));
+        assert_eq!(
+            serde_json::to_value(SessionState::Running).unwrap(),
+            json!("running")
+        );
+        assert_eq!(
+            serde_json::to_value(SessionState::Blocked).unwrap(),
+            json!("blocked")
+        );
+        assert_eq!(
+            serde_json::to_value(SessionState::Idle).unwrap(),
+            json!("idle")
+        );
+        assert_eq!(
+            serde_json::to_value(SessionState::Closed).unwrap(),
+            json!("closed")
+        );
     }
 
     #[test]

--- a/crates/agtop-core/src/state_resolution.rs
+++ b/crates/agtop-core/src/state_resolution.rs
@@ -1,0 +1,248 @@
+use chrono::{DateTime, Duration, Utc};
+
+use crate::process::Liveness;
+use crate::session::{SessionAnalysis, SessionState};
+
+pub const DEFAULT_STALLED_AFTER: Duration = Duration::minutes(5);
+
+/// Threshold for sessions running long tool operations before considering them stalled.
+/// Reserved for future use when tool-type classification is available.
+#[allow(dead_code)]
+pub const LONG_TOOL_STALLED_AFTER: Duration = Duration::minutes(10);
+
+/// Returns true if the session has a PID and hasn't been confirmed stopped.
+/// Sessions with `liveness = None` (not yet polled) are treated optimistically as live.
+#[must_use]
+fn is_live(a: &SessionAnalysis) -> bool {
+    a.pid.is_some() && !matches!(a.liveness, Some(Liveness::Stopped))
+}
+
+#[must_use]
+fn latest_activity(a: &SessionAnalysis) -> Option<DateTime<Utc>> {
+    a.children
+        .iter()
+        .filter_map(latest_activity)
+        .chain(a.summary.last_active)
+        .max()
+}
+
+#[must_use]
+fn priority(state: SessionState) -> u8 {
+    match state {
+        SessionState::AwaitingPermission => 0,
+        SessionState::AwaitingInput => 1,
+        SessionState::Running => 2,
+        SessionState::Stalled => 3,
+        SessionState::Idle => 4,
+        SessionState::Closed => 5,
+        SessionState::Unknown => 6,
+    }
+}
+
+pub fn resolve_session_states(analyses: &mut [SessionAnalysis], now: DateTime<Utc>) {
+    for analysis in analyses {
+        resolve_one(analysis, now);
+    }
+}
+
+fn resolve_one(analysis: &mut SessionAnalysis, now: DateTime<Utc>) -> SessionState {
+    for child in &mut analysis.children {
+        resolve_one(child, now);
+    }
+
+    if !is_live(analysis) {
+        analysis.summary.state = Some(SessionState::Closed);
+        analysis.summary.state_detail = Some("liveness=none".to_string());
+        return SessionState::Closed;
+    }
+
+    let child_best = analysis
+        .children
+        .iter()
+        .filter_map(|child| {
+            child
+                .summary
+                .state
+                .map(|state| (state, child.summary.session_id.as_str()))
+        })
+        .filter(|(state, _)| {
+            !matches!(
+                state,
+                SessionState::Closed | SessionState::Unknown | SessionState::Idle
+            )
+        })
+        .min_by_key(|(state, _)| priority(*state));
+
+    if let Some((state, child_id)) = child_best {
+        analysis.summary.state = Some(state);
+        analysis.summary.state_detail = Some(format!("child={child_id}:{}", state.as_str()));
+        return state;
+    }
+
+    let state = analysis.summary.state.unwrap_or(SessionState::Unknown);
+    let resolved = if state == SessionState::Running {
+        let inactive = latest_activity(analysis)
+            .map(|last| now.signed_duration_since(last) >= DEFAULT_STALLED_AFTER)
+            .unwrap_or(false);
+        if inactive {
+            analysis.summary.state_detail = Some(format!(
+                "stalled.no_activity={}m",
+                DEFAULT_STALLED_AFTER.num_minutes()
+            ));
+            SessionState::Stalled
+        } else {
+            SessionState::Running
+        }
+    } else {
+        state
+    };
+
+    analysis.summary.state = Some(resolved);
+    resolved
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{ClientKind, CostBreakdown, SessionSummary, TokenTotals};
+    use chrono::TimeZone;
+    use std::path::PathBuf;
+
+    fn analysis(
+        id: &str,
+        state: Option<SessionState>,
+        last_active: DateTime<Utc>,
+        live: bool,
+    ) -> SessionAnalysis {
+        let mut a = SessionAnalysis::new(
+            SessionSummary::new(
+                ClientKind::Claude,
+                None,
+                id.to_string(),
+                Some(last_active),
+                Some(last_active),
+                Some("model".to_string()),
+                Some("/tmp".to_string()),
+                PathBuf::from(format!("/tmp/{id}.jsonl")),
+                state,
+                None,
+                None,
+                None,
+            ),
+            TokenTotals::default(),
+            CostBreakdown::default(),
+            None,
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        if live {
+            a.pid = Some(42);
+            a.liveness = Some(Liveness::Live);
+        }
+        a
+    }
+
+    #[test]
+    fn non_live_sessions_resolve_to_closed() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap();
+        let mut analyses = vec![analysis("s1", Some(SessionState::Idle), now, false)];
+
+        resolve_session_states(&mut analyses, now);
+
+        assert_eq!(analyses[0].summary.state, Some(SessionState::Closed));
+        assert_eq!(
+            analyses[0].summary.state_detail.as_deref(),
+            Some("liveness=none")
+        );
+    }
+
+    #[test]
+    fn child_awaiting_permission_bubbles_to_parent() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap();
+        let mut parent = analysis("parent", Some(SessionState::Idle), now, true);
+        parent.children = vec![analysis(
+            "child",
+            Some(SessionState::AwaitingPermission),
+            now,
+            true,
+        )];
+        let mut analyses = vec![parent];
+
+        resolve_session_states(&mut analyses, now);
+
+        assert_eq!(
+            analyses[0].summary.state,
+            Some(SessionState::AwaitingPermission)
+        );
+        assert!(analyses[0]
+            .summary
+            .state_detail
+            .as_deref()
+            .unwrap()
+            .contains("child=child"));
+    }
+
+    #[test]
+    fn active_child_running_keeps_idle_parent_running() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap();
+        let mut parent = analysis("parent", Some(SessionState::Idle), now, true);
+        parent.children = vec![analysis("child", Some(SessionState::Running), now, true)];
+        let mut analyses = vec![parent];
+
+        resolve_session_states(&mut analyses, now);
+
+        assert_eq!(analyses[0].summary.state, Some(SessionState::Running));
+    }
+
+    #[test]
+    fn old_running_session_without_child_progress_resolves_to_stalled() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap();
+        let old = now - Duration::minutes(6);
+        let mut analyses = vec![analysis("s1", Some(SessionState::Running), old, true)];
+
+        resolve_session_states(&mut analyses, now);
+
+        assert_eq!(analyses[0].summary.state, Some(SessionState::Stalled));
+        assert_eq!(
+            analyses[0].summary.state_detail.as_deref(),
+            Some("stalled.no_activity=5m")
+        );
+    }
+
+    #[test]
+    fn grandchild_awaiting_permission_bubbles_to_grandparent() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap();
+        let mut grandparent = analysis("gp", Some(SessionState::Idle), now, true);
+        let mut parent = analysis("parent", Some(SessionState::Idle), now, true);
+        parent.children = vec![analysis(
+            "child",
+            Some(SessionState::AwaitingPermission),
+            now,
+            true,
+        )];
+        grandparent.children = vec![parent];
+        let mut analyses = vec![grandparent];
+
+        resolve_session_states(&mut analyses, now);
+
+        assert_eq!(
+            analyses[0].summary.state,
+            Some(SessionState::AwaitingPermission)
+        );
+    }
+
+    #[test]
+    fn recent_running_session_stays_running() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap();
+        let recent = now - Duration::minutes(2);
+        let mut analyses = vec![analysis("s1", Some(SessionState::Running), recent, true)];
+
+        resolve_session_states(&mut analyses, now);
+
+        assert_eq!(analyses[0].summary.state, Some(SessionState::Running));
+    }
+}

--- a/crates/agtop-core/tests/codex_fixture.rs
+++ b/crates/agtop-core/tests/codex_fixture.rs
@@ -13,7 +13,8 @@ use std::sync::{
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use agtop_core::clients::codex::CodexClient;
-use agtop_core::{Client, ClientKind, Plan, SessionSummary};
+use agtop_core::session::{ClientKind, SessionState, SessionSummary};
+use agtop_core::{Client, Plan};
 
 // ---------------------------------------------------------------------------
 // Minimal temp-dir helper (mirrors the one in the codex unit tests)
@@ -193,7 +194,7 @@ fn codex_fixture_extracts_effort_and_waiting_state() {
         summary.model_effort_detail.as_deref(),
         Some("turn_context.effort")
     );
-    assert_eq!(summary.state.as_deref(), Some("waiting"));
+    assert_eq!(summary.state, Some(SessionState::Running));
     assert_eq!(
         summary.state_detail.as_deref(),
         Some("response_item:function_call")

--- a/crates/agtop-core/tests/opencode_fixture.rs
+++ b/crates/agtop-core/tests/opencode_fixture.rs
@@ -12,7 +12,8 @@ use std::sync::{
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use agtop_core::clients::opencode::OpenCodeClient;
-use agtop_core::{Client, ClientKind, Plan, SessionSummary};
+use agtop_core::session::{ClientKind, SessionState, SessionSummary};
+use agtop_core::{Client, Plan};
 
 // ---------------------------------------------------------------------------
 // Temp-dir helper
@@ -356,8 +357,8 @@ fn opencode_sqlite_children_follow_parent_id() {
     assert_eq!(children[1].session_id, "ses_child_a");
     assert_eq!(children[0].cwd.as_deref(), Some("/tmp/opencode-child-b"));
     assert_eq!(children[0].model.as_deref(), Some(MODEL_ID));
-    assert_eq!(children[0].state.as_deref(), Some("stopped"));
-    assert_eq!(children[1].state.as_deref(), Some("waiting"));
+    assert_eq!(children[0].state, Some(SessionState::Idle));
+    assert_eq!(children[1].state, Some(SessionState::Running));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a typed `SessionState` enum (`Running`, `Blocked`, `Idle`, `Closed`) to `agtop-core::session`, replacing free-form `waiting`/`stopped` strings
- Updates all client parsers (Claude, Codex, OpenCode, Gemini, Copilot) to emit typed state values with precise semantics: tool calls → `Running`, explicit user prompts → `Blocked`, finished turns → `Idle`
- Replaces timestamp-based stale heuristics in `display_state` with PID/liveness-aware classification: no live PID → `closed`, live process → state from transcript
- `JsonSession.state` now serializes as typed enum (stable lowercase strings `running`/`blocked`/`idle`/`closed`)

## Motivation

`waiting` was overloaded: it meant both "agent is calling a tool" and "agent is waiting for the user to answer a question or approve a permission". The new states make these distinct:

| Old | New | When |
|-----|-----|------|
| `waiting` | `running` | Tool calls / tool responses in progress |
| `waiting` | `blocked` | Explicit user action required (question, permission) |
| `stopped` | `idle` | Turn finished, process still alive |
| *(inferred from timestamp)* | `closed` | No live PID associated |

## Test Plan

- [ ] `cargo test` — 513 passing, 6 ignored
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — 0 errors
- [ ] TUI renders `running`/`blocked`/`idle`/`closed` in the state column
- [ ] `--json` output has `state: "idle"` (not `"stopped"`) for finished sessions