### PR TITLE
feat(process): live CPU, memory, and disk metrics per session

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ details, data sources, and implementation notes.
 
 When an agent CLI is running, agtop correlates its OS process to the
 session transcript it's writing. The session table's `PID` column shows
-the live PID; the info panel shows liveness state (`live` / `stopped`)
-and how the match was established.
+the live PID; the **Process** tab in the bottom panel shows liveness
+state (`live` / `stopped`), match confidence, and live resource metrics
+(CPU usage, resident memory, virtual memory, cumulative disk I/O).
 
 Correlation uses the session id literal in argv (`--resume <uuid>`,
 `-s <ses_…>`) as the most-confident signal, the transcript file held
@@ -45,6 +46,14 @@ On Windows the score-only fallback still works but may be ambiguous
 when multiple agents run in the same cwd.
 
 ## Status
+
+**v0.4** adds live process metrics. Each matched session now surfaces CPU
+usage, resident/virtual memory, and cumulative disk I/O sampled from the
+OS on every refresh. New TUI columns `CPU` and `MEM` are visible by
+default (plus `VSZ`, `DISK R`, `DISK W` in the Config tab); a dedicated
+**Process** bottom-panel tab shows all metrics with room to read them.
+The `--list` table gains `PID`, `CPU`, and `MEM` columns; `--json` adds
+a `process_metrics` field.
 
 **v0.3** adds session ↔ OS-process correlation. When a CLI is running
 agtop binds the right PID to the right session row across all
@@ -127,7 +136,7 @@ pre-logo builds. No configuration knob is needed.
 | `F6` or `>`          | Cycle sort column                        |
 | `i`                  | Flip sort direction                      |
 | `d`                  | Toggle classic/dashboard layout          |
-| Tab / Shift-Tab      | Cycle bottom-panel tabs (Info, Cost)     |
+| Tab / Shift-Tab      | Cycle bottom-panel tabs (Info, Process, Cost, …) |
 | `F5` or `r`          | Manual refresh                           |
 | `q` / `F10` / Ctrl-C | Quit                                     |
 
@@ -152,11 +161,14 @@ Core types:
 
 - `Client` trait: `list_sessions()` + `analyze(summary, plan)`.
 - `SessionSummary`: metadata discovered without re-reading the full transcript.
-- `SessionAnalysis`: summary + `TokenTotals` + `CostBreakdown`.
+- `SessionAnalysis`: summary + `TokenTotals` + `CostBreakdown` + `ProcessMetrics`.
 - `PlanUsage`: best-effort plan/limit snapshots for dashboard panes.
+- `ProcessCorrelator`: matches sessions to live OS processes and samples resource metrics each refresh.
 
-The client layer is `Send + Sync`, so the upcoming TUI can drive it from
-a background refresh thread.
+The client layer is `Send + Sync`; the TUI drives it from a background
+refresh thread. `ProcessCorrelator` is stateful (retains prior snapshot
+to emit a transient `Stopped` frame when a process exits) and must be
+held across refresh iterations rather than re-created each cycle.
 
 ## Testing
 

--- a/crates/agtop-cli/src/fmt.rs
+++ b/crates/agtop-cli/src/fmt.rs
@@ -107,7 +107,7 @@ pub fn format_duration_compact(secs: u64) -> String {
 
 /// Format an optional CPU percentage with one decimal place.
 /// Returns `"-"` when the value is absent.
-pub fn percent_1(value: Option<f32>) -> String {
+pub fn format_percent(value: Option<f32>) -> String {
     value
         .map(|v| format!("{v:.1}%"))
         .unwrap_or_else(|| "-".to_string())

--- a/crates/agtop-cli/src/fmt.rs
+++ b/crates/agtop-cli/src/fmt.rs
@@ -105,6 +105,20 @@ pub fn format_duration_compact(secs: u64) -> String {
 // Table cell formatting (CLI --list table)
 // ---------------------------------------------------------------------------
 
+/// Format an optional CPU percentage with one decimal place.
+/// Returns `"-"` when the value is absent.
+pub fn percent_1(value: Option<f32>) -> String {
+    value
+        .map(|v| format!("{v:.1}%"))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+/// Format an optional byte count using [`compact`].
+/// Returns `"-"` when the value is absent.
+pub fn compact_opt(value: Option<u64>) -> String {
+    value.map(compact).unwrap_or_else(|| "-".to_string())
+}
+
 /// Fit `s` into a field of exactly `w` display columns: pad with spaces if
 /// shorter, truncate with an ellipsis (`…`) if longer.
 pub fn fit(s: &str, w: usize) -> String {

--- a/crates/agtop-cli/src/main.rs
+++ b/crates/agtop-cli/src/main.rs
@@ -235,6 +235,7 @@ fn run_watch(
     // Hide the cursor while redrawing to avoid flicker.
     let _ = execute!(stdout, cursor::Hide);
     let result = (|| -> Result<()> {
+        let mut correlator = agtop_core::ProcessCorrelator::new();
         while running.load(Ordering::SeqCst) {
             // Clear screen + move to top-left before each render.
             execute!(
@@ -246,7 +247,7 @@ fn run_watch(
 
             let mut analyses = analyze_all(clients, plan);
             let summaries: Vec<_> = analyses.iter().map(|a| a.summary.clone()).collect();
-            let info_map = agtop_core::ProcessCorrelator::new().snapshot(&summaries);
+            let info_map = correlator.snapshot(&summaries);
             agtop_core::process::attach_process_info(&info_map, &mut analyses);
             let summaries = discover_all(clients);
             render_table(&summaries, &analyses);
@@ -455,6 +456,8 @@ mod client_parse_tests {
 }
 
 fn render_table(summaries: &[agtop_core::SessionSummary], analyses: &[SessionAnalysis]) {
+    // 14 columns (10+16+10+16+4+20+18+9+9+9+8+7+6+7) + 13 × 2-space gaps
+    const TABLE_WIDTH: usize = 175;
     // Index analyses by session_id for quick lookup.
     use std::collections::HashMap;
     let by_id: HashMap<&str, &SessionAnalysis> = analyses
@@ -480,7 +483,7 @@ fn render_table(summaries: &[agtop_core::SessionSummary], analyses: &[SessionAna
         "CPU",
         "MEM"
     );
-    println!("{}", "-".repeat(184));
+    println!("{}", "-".repeat(TABLE_WIDTH));
 
     let mut printed = 0usize;
     for s in summaries {
@@ -534,7 +537,7 @@ fn render_table(summaries: &[agtop_core::SessionSummary], analyses: &[SessionAna
             Some(a) => a.pid.map(|p| p.to_string()).unwrap_or_else(|| "-".into()),
             None => "-".into(),
         };
-        let cpu_str = fmt::percent_1(a.and_then(|a| a.process_metrics.as_ref().map(|m| m.cpu_percent)));
+        let cpu_str = fmt::format_percent(a.and_then(|a| a.process_metrics.as_ref().map(|m| m.cpu_percent)));
         let mem_str = fmt::compact_opt(a.and_then(|a| a.process_metrics.as_ref().map(|m| m.memory_bytes)));
         println!(
             "{:<10}  {:<16}  {:<10}  {:<16}  {:>4}  {:<20}  {:<18}  {:>9}  {:>9}  {:>9}  {:>8}  {:>7}  {:>6}  {:>7}",
@@ -568,7 +571,7 @@ fn render_table(summaries: &[agtop_core::SessionSummary], analyses: &[SessionAna
 
     // Footer totals.
     let totals = JsonTotals::from(&analyses.to_vec());
-    println!("{}", "-".repeat(184));
+    println!("{}", "-".repeat(TABLE_WIDTH));
     println!(
         "totals: {} sessions  in={}  out={}  cache={}  cost=${:.4} (billed)  incl.sessions={}",
         analyses.len(),

--- a/crates/agtop-cli/src/main.rs
+++ b/crates/agtop-cli/src/main.rs
@@ -537,8 +537,10 @@ fn render_table(summaries: &[agtop_core::SessionSummary], analyses: &[SessionAna
             Some(a) => a.pid.map(|p| p.to_string()).unwrap_or_else(|| "-".into()),
             None => "-".into(),
         };
-        let cpu_str = fmt::format_percent(a.and_then(|a| a.process_metrics.as_ref().map(|m| m.cpu_percent)));
-        let mem_str = fmt::compact_opt(a.and_then(|a| a.process_metrics.as_ref().map(|m| m.memory_bytes)));
+        let cpu_str =
+            fmt::format_percent(a.and_then(|a| a.process_metrics.as_ref().map(|m| m.cpu_percent)));
+        let mem_str =
+            fmt::compact_opt(a.and_then(|a| a.process_metrics.as_ref().map(|m| m.memory_bytes)));
         println!(
             "{:<10}  {:<16}  {:<10}  {:<16}  {:>4}  {:<20}  {:<18}  {:>9}  {:>9}  {:>9}  {:>8}  {:>7}  {:>6}  {:>7}",
             s.client.as_str(),
@@ -732,8 +734,14 @@ mod json_output_tests {
 
         assert_eq!(json.state.as_deref(), Some("stopped"));
         assert_eq!(json.display_state, "working");
-        assert_eq!(json.process_metrics.as_ref().map(|m| m.cpu_percent), Some(3.5));
-        assert_eq!(json.process_metrics.as_ref().map(|m| m.disk_written_bytes), Some(12));
+        assert_eq!(
+            json.process_metrics.as_ref().map(|m| m.cpu_percent),
+            Some(3.5)
+        );
+        assert_eq!(
+            json.process_metrics.as_ref().map(|m| m.disk_written_bytes),
+            Some(12)
+        );
     }
 
     #[test]

--- a/crates/agtop-cli/src/main.rs
+++ b/crates/agtop-cli/src/main.rs
@@ -184,7 +184,10 @@ fn main() -> Result<()> {
         run_watch(&live, plan, cli.delay.max(1))?;
     } else if cli.list {
         let live = filtered_clients(&clients, &enabled_initial);
-        let analyses = analyze_all(&live, plan);
+        let mut analyses = analyze_all(&live, plan);
+        let summaries: Vec<_> = analyses.iter().map(|a| a.summary.clone()).collect();
+        let info_map = agtop_core::ProcessCorrelator::new().snapshot(&summaries);
+        agtop_core::process::attach_process_info(&info_map, &mut analyses);
         let summaries = discover_all(&live);
         render_table(&summaries, &analyses);
     } else {
@@ -241,7 +244,10 @@ fn run_watch(
             )
             .context("clear screen")?;
 
-            let analyses = analyze_all(clients, plan);
+            let mut analyses = analyze_all(clients, plan);
+            let summaries: Vec<_> = analyses.iter().map(|a| a.summary.clone()).collect();
+            let info_map = agtop_core::ProcessCorrelator::new().snapshot(&summaries);
+            agtop_core::process::attach_process_info(&info_map, &mut analyses);
             let summaries = discover_all(clients);
             render_table(&summaries, &analyses);
             writeln!(
@@ -458,7 +464,7 @@ fn render_table(summaries: &[agtop_core::SessionSummary], analyses: &[SessionAna
 
     let now = Utc::now();
     println!(
-        "{:<10}  {:<16}  {:<10}  {:<16}  {:>4}  {:<20}  {:<18}  {:>9}  {:>9}  {:>9}  {:>8}",
+        "{:<10}  {:<16}  {:<10}  {:<16}  {:>4}  {:<20}  {:<18}  {:>9}  {:>9}  {:>9}  {:>8}  {:>7}  {:>6}  {:>7}",
         "CLIENT",
         "SUBSCRIPTION",
         "SESSION",
@@ -469,9 +475,12 @@ fn render_table(summaries: &[agtop_core::SessionSummary], analyses: &[SessionAna
         "IN",
         "OUT",
         "CACHE",
-        "COST$"
+        "COST$",
+        "PID",
+        "CPU",
+        "MEM"
     );
-    println!("{}", "-".repeat(160));
+    println!("{}", "-".repeat(184));
 
     let mut printed = 0usize;
     for s in summaries {
@@ -521,8 +530,14 @@ fn render_table(summaries: &[agtop_core::SessionSummary], analyses: &[SessionAna
             .last_active
             .map(|t| fmt::relative_age(t, now))
             .unwrap_or_else(|| "-".into());
+        let pid_str = match a {
+            Some(a) => a.pid.map(|p| p.to_string()).unwrap_or_else(|| "-".into()),
+            None => "-".into(),
+        };
+        let cpu_str = fmt::percent_1(a.and_then(|a| a.process_metrics.as_ref().map(|m| m.cpu_percent)));
+        let mem_str = fmt::compact_opt(a.and_then(|a| a.process_metrics.as_ref().map(|m| m.memory_bytes)));
         println!(
-            "{:<10}  {:<16}  {:<10}  {:<16}  {:>4}  {:<20}  {:<18}  {:>9}  {:>9}  {:>9}  {:>8}",
+            "{:<10}  {:<16}  {:<10}  {:<16}  {:>4}  {:<20}  {:<18}  {:>9}  {:>9}  {:>9}  {:>8}  {:>7}  {:>6}  {:>7}",
             s.client.as_str(),
             fmt::fit(&subscription, 16),
             fmt::fit(&short_session, 10),
@@ -534,6 +549,9 @@ fn render_table(summaries: &[agtop_core::SessionSummary], analyses: &[SessionAna
             output,
             cache,
             cost_str,
+            pid_str,
+            cpu_str,
+            mem_str,
         );
         printed += 1;
         if printed >= 200 {
@@ -550,7 +568,7 @@ fn render_table(summaries: &[agtop_core::SessionSummary], analyses: &[SessionAna
 
     // Footer totals.
     let totals = JsonTotals::from(&analyses.to_vec());
-    println!("{}", "-".repeat(160));
+    println!("{}", "-".repeat(184));
     println!(
         "totals: {} sessions  in={}  out={}  cache={}  cost=${:.4} (billed)  incl.sessions={}",
         analyses.len(),
@@ -617,6 +635,11 @@ struct JsonSession {
     /// `null` when no match was established.
     #[serde(default)]
     match_confidence: Option<agtop_core::Confidence>,
+    /// Live OS resource metrics for the matched process.
+    /// `null` when no process is matched, process has stopped, or metrics
+    /// could not be read.
+    #[serde(default)]
+    process_metrics: Option<agtop_core::process::ProcessMetrics>,
 }
 
 impl From<&SessionAnalysis> for JsonSession {
@@ -654,6 +677,7 @@ impl JsonSession {
             pid: a.pid,
             liveness: a.liveness,
             match_confidence: a.match_confidence,
+            process_metrics: a.process_metrics.clone(),
         }
     }
 }
@@ -681,7 +705,7 @@ mod json_output_tests {
             None,
             None,
         );
-        let analysis = SessionAnalysis::new(
+        let mut analysis = SessionAnalysis::new(
             summary,
             TokenTotals::default(),
             CostBreakdown::default(),
@@ -693,11 +717,20 @@ mod json_output_tests {
             None,
             None,
         );
+        analysis.process_metrics = Some(agtop_core::process::ProcessMetrics {
+            cpu_percent: 3.5,
+            memory_bytes: 1234,
+            virtual_memory_bytes: 5678,
+            disk_read_bytes: 90,
+            disk_written_bytes: 12,
+        });
 
         let json = JsonSession::from_analysis(&analysis, now);
 
         assert_eq!(json.state.as_deref(), Some("stopped"));
         assert_eq!(json.display_state, "working");
+        assert_eq!(json.process_metrics.as_ref().map(|m| m.cpu_percent), Some(3.5));
+        assert_eq!(json.process_metrics.as_ref().map(|m| m.disk_written_bytes), Some(12));
     }
 
     #[test]

--- a/crates/agtop-cli/src/tui/app/mod.rs
+++ b/crates/agtop-cli/src/tui/app/mod.rs
@@ -71,6 +71,7 @@ pub enum UiMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Tab {
     Info,
+    Process,
     Cost,
     Config,
     Quota,
@@ -78,12 +79,13 @@ pub enum Tab {
 
 impl Tab {
     pub fn all() -> &'static [Tab] {
-        &[Tab::Info, Tab::Cost, Tab::Config, Tab::Quota]
+        &[Tab::Info, Tab::Process, Tab::Cost, Tab::Config, Tab::Quota]
     }
 
     pub fn title(self) -> &'static str {
         match self {
             Self::Info => "Info",
+            Self::Process => "Process",
             Self::Cost => "Cost",
             Self::Config => "Config",
             Self::Quota => "Quota",
@@ -92,7 +94,8 @@ impl Tab {
 
     pub fn cycle_forward(self) -> Self {
         match self {
-            Self::Info => Self::Cost,
+            Self::Info => Self::Process,
+            Self::Process => Self::Cost,
             Self::Cost => Self::Config,
             Self::Config => Self::Quota,
             Self::Quota => Self::Info,
@@ -102,7 +105,8 @@ impl Tab {
     pub fn cycle_back(self) -> Self {
         match self {
             Self::Info => Self::Quota,
-            Self::Cost => Self::Info,
+            Self::Process => Self::Info,
+            Self::Cost => Self::Process,
             Self::Config => Self::Cost,
             Self::Quota => Self::Config,
         }
@@ -1373,9 +1377,19 @@ mod tests {
     }
 
     #[test]
+    fn tab_process_is_between_info_and_cost() {
+        assert_eq!(Tab::Info.cycle_forward(), Tab::Process);
+        assert_eq!(Tab::Process.cycle_forward(), Tab::Cost);
+        assert_eq!(Tab::Cost.cycle_back(), Tab::Process);
+        assert_eq!(Tab::Process.cycle_back(), Tab::Info);
+    }
+
+    #[test]
     fn tab_cycles() {
         let mut app = App::new();
         assert_eq!(app.tab(), Tab::Info);
+        app.next_tab();
+        assert_eq!(app.tab(), Tab::Process);
         app.next_tab();
         assert_eq!(app.tab(), Tab::Cost);
         app.next_tab();

--- a/crates/agtop-cli/src/tui/column_config.rs
+++ b/crates/agtop-cli/src/tui/column_config.rs
@@ -224,6 +224,29 @@ impl ColumnId {
     }
 }
 
+/// Returns the default visibility for a column in a fresh or migrated config.
+fn default_visible(id: ColumnId) -> bool {
+    matches!(
+        id,
+        ColumnId::Session
+            | ColumnId::Age
+            | ColumnId::Client
+            | ColumnId::Subscription
+            | ColumnId::Model
+            | ColumnId::Effort
+            | ColumnId::State
+            | ColumnId::Tokens
+            | ColumnId::OutputTokens
+            | ColumnId::CacheTokens
+            | ColumnId::Context
+            | ColumnId::Cost
+            | ColumnId::Project
+            | ColumnId::Pid
+            | ColumnId::Cpu
+            | ColumnId::Memory
+    )
+}
+
 fn default_sort_col() -> SortColumn {
     SortColumn::LastActive
 }
@@ -278,25 +301,7 @@ impl Default for ColumnConfig {
                 .iter()
                 .map(|&id| ColumnEntry {
                     id,
-                    visible: matches!(
-                        id,
-                        ColumnId::Session
-                            | ColumnId::Age
-                            | ColumnId::Client
-                            | ColumnId::Subscription
-                            | ColumnId::Model
-                            | ColumnId::Effort
-                            | ColumnId::State
-                            | ColumnId::Tokens
-                            | ColumnId::OutputTokens
-                            | ColumnId::CacheTokens
-                            | ColumnId::Context
-                            | ColumnId::Cost
-                            | ColumnId::Project
-                            | ColumnId::Pid
-                            | ColumnId::Cpu
-                            | ColumnId::Memory
-                    ),
+                    visible: default_visible(id),
                 })
                 .collect(),
             sort_col,
@@ -318,26 +323,7 @@ impl ColumnConfig {
         let existing_ids: Vec<ColumnId> = self.columns.iter().map(|e| e.id).collect();
         for &id in ColumnId::all() {
             if !existing_ids.contains(&id) {
-                let visible = matches!(
-                    id,
-                    ColumnId::Session
-                        | ColumnId::Age
-                        | ColumnId::Client
-                        | ColumnId::Subscription
-                        | ColumnId::Model
-                        | ColumnId::Effort
-                        | ColumnId::State
-                        | ColumnId::Tokens
-                        | ColumnId::OutputTokens
-                        | ColumnId::CacheTokens
-                        | ColumnId::Context
-                        | ColumnId::Cost
-                        | ColumnId::Project
-                        | ColumnId::Pid
-                        | ColumnId::Cpu
-                        | ColumnId::Memory
-                );
-                self.columns.push(ColumnEntry { id, visible });
+                self.columns.push(ColumnEntry { id, visible: default_visible(id) });
             }
         }
         self
@@ -673,6 +659,11 @@ mod cfg_client_tests {
     fn old_config_gets_new_metric_columns_appended() {
         let json = r#"{"columns":[{"id":"session","visible":true},{"id":"pid","visible":true}],"sort_col":"last_active","sort_dir":"desc","clients":[]}"#;
         let cfg: ColumnConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            cfg.columns.len(),
+            ColumnId::all().len(),
+            "normalize must not produce duplicate columns"
+        );
         // New columns must be appended with their default visibility.
         assert!(cfg.columns.iter().any(|c| c.id == ColumnId::Cpu),
             "Cpu column must be present after normalization");
@@ -700,6 +691,8 @@ mod cfg_client_tests {
             ColumnId::Cost,
             ColumnId::Project,
             ColumnId::Pid,
+            ColumnId::Cpu,
+            ColumnId::Memory,
         ] {
             assert!(
                 visible.contains(id),

--- a/crates/agtop-cli/src/tui/column_config.rs
+++ b/crates/agtop-cli/src/tui/column_config.rs
@@ -38,6 +38,16 @@ pub enum ColumnId {
     Project,
     SessionName,
     Pid,
+    /// Live CPU usage of the matched process (percentage).
+    Cpu,
+    /// Resident memory of the matched process (bytes, compact format).
+    Memory,
+    /// Virtual memory of the matched process (bytes, compact format).
+    VirtualMemory,
+    /// Cumulative disk bytes read by the matched process.
+    DiskRead,
+    /// Cumulative disk bytes written by the matched process.
+    DiskWritten,
 }
 
 impl ColumnId {
@@ -55,6 +65,11 @@ impl ColumnId {
             ColumnId::Effort,
             ColumnId::State,
             ColumnId::Pid,
+            ColumnId::Cpu,
+            ColumnId::Memory,
+            ColumnId::VirtualMemory,
+            ColumnId::DiskRead,
+            ColumnId::DiskWritten,
             ColumnId::Tokens,
             ColumnId::OutputTokens,
             ColumnId::CacheTokens,
@@ -94,6 +109,11 @@ impl ColumnId {
             ColumnId::Project => "PROJECT",
             ColumnId::SessionName => "NAME",
             ColumnId::Pid => "PID",
+            ColumnId::Cpu => "CPU",
+            ColumnId::Memory => "MEM",
+            ColumnId::VirtualMemory => "VSZ",
+            ColumnId::DiskRead => "DISK R",
+            ColumnId::DiskWritten => "DISK W",
         }
     }
 
@@ -122,6 +142,11 @@ impl ColumnId {
             ColumnId::Project => "Inferred project name (from git remote)",
             ColumnId::SessionName => "Session title/name set by the agent",
             ColumnId::Pid => "OS process ID of the live agent CLI",
+            ColumnId::Cpu => "Live CPU usage of the matched process (%)",
+            ColumnId::Memory => "Live resident memory of the matched process",
+            ColumnId::VirtualMemory => "Live virtual memory of the matched process",
+            ColumnId::DiskRead => "Cumulative bytes read from disk (since process start)",
+            ColumnId::DiskWritten => "Cumulative bytes written to disk (since process start)",
         }
     }
 
@@ -151,6 +176,11 @@ impl ColumnId {
             ColumnId::Project => Some(16),
             ColumnId::SessionName => Some(24),
             ColumnId::Pid => Some(7), // 6 digits + padding
+            ColumnId::Cpu => Some(6),
+            ColumnId::Memory => Some(7),
+            ColumnId::VirtualMemory => Some(7),
+            ColumnId::DiskRead => Some(8),
+            ColumnId::DiskWritten => Some(8),
         }
     }
 
@@ -180,6 +210,11 @@ impl ColumnId {
             ColumnId::Project => Some(SortColumn::Project),
             ColumnId::SessionName => None,
             ColumnId::Pid => None, // not sortable
+            ColumnId::Cpu => None,
+            ColumnId::Memory => None,
+            ColumnId::VirtualMemory => None,
+            ColumnId::DiskRead => None,
+            ColumnId::DiskWritten => None,
         }
     }
 
@@ -259,6 +294,8 @@ impl Default for ColumnConfig {
                             | ColumnId::Cost
                             | ColumnId::Project
                             | ColumnId::Pid
+                            | ColumnId::Cpu
+                            | ColumnId::Memory
                     ),
                 })
                 .collect(),
@@ -274,6 +311,34 @@ impl ColumnConfig {
         if self.sort_col == SortColumn::Cost {
             self.sort_col = SortColumn::LastActive;
             self.sort_dir = SortColumn::LastActive.default_direction();
+        }
+        // Append any new columns not present in the persisted config.
+        // This ensures old configs gain new columns on upgrade without
+        // losing their existing column order or visibility.
+        let existing_ids: Vec<ColumnId> = self.columns.iter().map(|e| e.id).collect();
+        for &id in ColumnId::all() {
+            if !existing_ids.contains(&id) {
+                let visible = matches!(
+                    id,
+                    ColumnId::Session
+                        | ColumnId::Age
+                        | ColumnId::Client
+                        | ColumnId::Subscription
+                        | ColumnId::Model
+                        | ColumnId::Effort
+                        | ColumnId::State
+                        | ColumnId::Tokens
+                        | ColumnId::OutputTokens
+                        | ColumnId::CacheTokens
+                        | ColumnId::Context
+                        | ColumnId::Cost
+                        | ColumnId::Project
+                        | ColumnId::Pid
+                        | ColumnId::Cpu
+                        | ColumnId::Memory
+                );
+                self.columns.push(ColumnEntry { id, visible });
+            }
         }
         self
     }
@@ -564,7 +629,10 @@ mod cfg_client_tests {
 
         let cfg: ColumnConfig =
             serde_json::from_str(json).expect("deserialize legacy provider config");
-        assert_eq!(cfg.columns.len(), 1);
+        // After normalization, missing columns are appended so the total count
+        // equals the full column list. The originally persisted column (Client,
+        // from the "provider" alias) must remain first.
+        assert_eq!(cfg.columns.len(), ColumnId::all().len());
         assert_eq!(cfg.columns[0].id, ColumnId::Client);
         assert_eq!(cfg.sort_col, SortColumn::Client);
         assert_eq!(cfg.sort_dir, SortDir::Asc);
@@ -599,6 +667,22 @@ mod cfg_client_tests {
         let cfg: ColumnConfig = serde_json::from_str(json).expect("deserialize");
         assert_eq!(cfg.sort_col, SortColumn::Tokens);
         assert_eq!(cfg.sort_dir, SortDir::Asc);
+    }
+
+    #[test]
+    fn old_config_gets_new_metric_columns_appended() {
+        let json = r#"{"columns":[{"id":"session","visible":true},{"id":"pid","visible":true}],"sort_col":"last_active","sort_dir":"desc","clients":[]}"#;
+        let cfg: ColumnConfig = serde_json::from_str(json).unwrap();
+        // New columns must be appended with their default visibility.
+        assert!(cfg.columns.iter().any(|c| c.id == ColumnId::Cpu),
+            "Cpu column must be present after normalization");
+        assert!(cfg.columns.iter().any(|c| c.id == ColumnId::Memory),
+            "Memory column must be present after normalization");
+        // Cpu and Memory are visible by default; the others are hidden.
+        let cpu = cfg.columns.iter().find(|c| c.id == ColumnId::Cpu).unwrap();
+        let mem = cfg.columns.iter().find(|c| c.id == ColumnId::Memory).unwrap();
+        assert!(cpu.visible, "Cpu should be visible by default");
+        assert!(mem.visible, "Memory should be visible by default");
     }
 
     #[test]

--- a/crates/agtop-cli/src/tui/column_config.rs
+++ b/crates/agtop-cli/src/tui/column_config.rs
@@ -323,7 +323,10 @@ impl ColumnConfig {
         let existing_ids: Vec<ColumnId> = self.columns.iter().map(|e| e.id).collect();
         for &id in ColumnId::all() {
             if !existing_ids.contains(&id) {
-                self.columns.push(ColumnEntry { id, visible: default_visible(id) });
+                self.columns.push(ColumnEntry {
+                    id,
+                    visible: default_visible(id),
+                });
             }
         }
         self
@@ -665,13 +668,21 @@ mod cfg_client_tests {
             "normalize must not produce duplicate columns"
         );
         // New columns must be appended with their default visibility.
-        assert!(cfg.columns.iter().any(|c| c.id == ColumnId::Cpu),
-            "Cpu column must be present after normalization");
-        assert!(cfg.columns.iter().any(|c| c.id == ColumnId::Memory),
-            "Memory column must be present after normalization");
+        assert!(
+            cfg.columns.iter().any(|c| c.id == ColumnId::Cpu),
+            "Cpu column must be present after normalization"
+        );
+        assert!(
+            cfg.columns.iter().any(|c| c.id == ColumnId::Memory),
+            "Memory column must be present after normalization"
+        );
         // Cpu and Memory are visible by default; the others are hidden.
         let cpu = cfg.columns.iter().find(|c| c.id == ColumnId::Cpu).unwrap();
-        let mem = cfg.columns.iter().find(|c| c.id == ColumnId::Memory).unwrap();
+        let mem = cfg
+            .columns
+            .iter()
+            .find(|c| c.id == ColumnId::Memory)
+            .unwrap();
         assert!(cpu.visible, "Cpu should be visible by default");
         assert!(mem.visible, "Memory should be visible by default");
     }

--- a/crates/agtop-cli/src/tui/events.rs
+++ b/crates/agtop-cli/src/tui/events.rs
@@ -546,7 +546,8 @@ mod tests {
     #[test]
     fn tab_into_quota_emits_start_action() {
         let mut app = App::new();
-        // Info → Cost → Config → Quota (3 tabs forward)
+        // Info → Process → Cost → Config → Quota (4 tabs forward)
+        apply_key(&mut app, press(KeyCode::Tab));
         apply_key(&mut app, press(KeyCode::Tab));
         apply_key(&mut app, press(KeyCode::Tab));
         let action = apply_key(&mut app, press(KeyCode::Tab));

--- a/crates/agtop-cli/src/tui/mod.rs
+++ b/crates/agtop-cli/src/tui/mod.rs
@@ -737,14 +737,7 @@ fn render_bottom_panel(frame: &mut Frame<'_>, area: Rect, app: &App, layout: &mu
 
     match app.tab() {
         Tab::Info => widgets::info_tab::render(frame, rows[1], app),
-        Tab::Process => {
-            // TODO(task-2): replaced by widgets::process_tab::render
-            frame.render_widget(
-                ratatui::widgets::Paragraph::new("(process tab coming soon)")
-                    .block(ratatui::widgets::Block::default().borders(ratatui::widgets::Borders::ALL).title(" Process ")),
-                rows[1],
-            );
-        }
+        Tab::Process => widgets::process_tab::render(frame, rows[1], app),
         Tab::Cost => widgets::cost_tab::render(frame, rows[1], app),
         Tab::Config => widgets::config_tab::render(
             frame,
@@ -1535,6 +1528,26 @@ mod tests {
         assert!(contents.contains("5h"), "5h missing:\n{contents}");
         assert!(contents.contains("42"), "percentage missing:\n{contents}");
         assert!(contents.contains('■'), "bar char missing:\n{contents}");
+    }
+
+    #[test]
+    fn process_tab_renders_without_panic() {
+        let backend = ratatui::backend::TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.set_tab(crate::tui::app::Tab::Process);
+        let mut table_state = ratatui::widgets::TableState::default();
+        let mut layout = UiLayout::default();
+        terminal
+            .draw(|frame| render(frame, &app, &mut table_state, &mut layout))
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let rendered: String = buf.content().iter().map(|c| c.symbol().to_string()).collect();
+        assert!(rendered.contains("Process"), "tab bar must show Process tab title");
+        assert!(
+            !rendered.contains("coming soon"),
+            "placeholder must be replaced by real widget"
+        );
     }
 
     #[test]

--- a/crates/agtop-cli/src/tui/mod.rs
+++ b/crates/agtop-cli/src/tui/mod.rs
@@ -927,7 +927,9 @@ mod tests {
     /// test robust against time-zone drift.
     #[test]
     fn renders_main_layout_without_panicking() {
-        let backend = TestBackend::new(140, 20);
+        // Width increased from 140→160 to accommodate the 2 new visible columns
+        // (CPU=6, MEM=7) added in the process-metrics feature branch.
+        let backend = TestBackend::new(160, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         let app = fixture_app();
         let mut state = ratatui::widgets::TableState::default();

--- a/crates/agtop-cli/src/tui/mod.rs
+++ b/crates/agtop-cli/src/tui/mod.rs
@@ -1542,8 +1542,15 @@ mod tests {
             .draw(|frame| render(frame, &app, &mut table_state, &mut layout))
             .unwrap();
         let buf = terminal.backend().buffer().clone();
-        let rendered: String = buf.content().iter().map(|c| c.symbol().to_string()).collect();
-        assert!(rendered.contains("Process"), "tab bar must show Process tab title");
+        let rendered: String = buf
+            .content()
+            .iter()
+            .map(|c| c.symbol().to_string())
+            .collect();
+        assert!(
+            rendered.contains("Process"),
+            "tab bar must show Process tab title"
+        );
         assert!(
             !rendered.contains("coming soon"),
             "placeholder must be replaced by real widget"

--- a/crates/agtop-cli/src/tui/mod.rs
+++ b/crates/agtop-cli/src/tui/mod.rs
@@ -737,7 +737,14 @@ fn render_bottom_panel(frame: &mut Frame<'_>, area: Rect, app: &App, layout: &mu
 
     match app.tab() {
         Tab::Info => widgets::info_tab::render(frame, rows[1], app),
-        Tab::Process => widgets::info_tab::render(frame, rows[1], app), // placeholder; Task 2 will implement
+        Tab::Process => {
+            // TODO(task-2): replaced by widgets::process_tab::render
+            frame.render_widget(
+                ratatui::widgets::Paragraph::new("(process tab coming soon)")
+                    .block(ratatui::widgets::Block::default().borders(ratatui::widgets::Borders::ALL).title(" Process ")),
+                rows[1],
+            );
+        }
         Tab::Cost => widgets::cost_tab::render(frame, rows[1], app),
         Tab::Config => widgets::config_tab::render(
             frame,

--- a/crates/agtop-cli/src/tui/mod.rs
+++ b/crates/agtop-cli/src/tui/mod.rs
@@ -698,9 +698,10 @@ fn render_bottom_panel(frame: &mut Frame<'_>, area: Rect, app: &App, layout: &mu
     let tab_bar = Tabs::new(titles)
         .select(match app.tab() {
             Tab::Info => 0,
-            Tab::Cost => 1,
-            Tab::Config => 2,
-            Tab::Quota => 3,
+            Tab::Process => 1,
+            Tab::Cost => 2,
+            Tab::Config => 3,
+            Tab::Quota => 4,
         })
         .block(Block::default().borders(Borders::NONE))
         .divider("│");
@@ -736,6 +737,7 @@ fn render_bottom_panel(frame: &mut Frame<'_>, area: Rect, app: &App, layout: &mu
 
     match app.tab() {
         Tab::Info => widgets::info_tab::render(frame, rows[1], app),
+        Tab::Process => widgets::info_tab::render(frame, rows[1], app), // placeholder; Task 2 will implement
         Tab::Cost => widgets::cost_tab::render(frame, rows[1], app),
         Tab::Config => widgets::config_tab::render(
             frame,

--- a/crates/agtop-cli/src/tui/widgets/info_tab.rs
+++ b/crates/agtop-cli/src/tui/widgets/info_tab.rs
@@ -340,6 +340,26 @@ fn column_line(col: ColumnId, a: &SessionAnalysis, now: DateTime<Utc>) -> Line<'
                 _ => "-".into(),
             },
         ),
+        ColumnId::Cpu => kv_line(
+            "cpu",
+            crate::fmt::format_percent(a.process_metrics.as_ref().map(|m| m.cpu_percent)),
+        ),
+        ColumnId::Memory => kv_line(
+            "memory",
+            crate::fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.memory_bytes)),
+        ),
+        ColumnId::VirtualMemory => kv_line(
+            "virtual_memory",
+            crate::fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.virtual_memory_bytes)),
+        ),
+        ColumnId::DiskRead => kv_line(
+            "disk_read",
+            crate::fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.disk_read_bytes)),
+        ),
+        ColumnId::DiskWritten => kv_line(
+            "disk_written",
+            crate::fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.disk_written_bytes)),
+        ),
         // SubscriptionLogo is injected by visible() — not displayed in info tab.
         ColumnId::SubscriptionLogo => Line::default(),
     }

--- a/crates/agtop-cli/src/tui/widgets/info_tab.rs
+++ b/crates/agtop-cli/src/tui/widgets/info_tab.rs
@@ -366,11 +366,7 @@ fn column_line(col: ColumnId, a: &SessionAnalysis, now: DateTime<Utc>) -> Line<'
 }
 
 fn kv_line(key: &'static str, value: String) -> Line<'static> {
-    Line::from(vec![
-        Span::styled(format!("{key:>16}"), th::INFO_KEY),
-        Span::raw("  "),
-        Span::raw(value),
-    ])
+    super::kv_line(key, value)
 }
 
 fn kv_line_styled(key: &'static str, value: String, style: Style) -> Line<'static> {

--- a/crates/agtop-cli/src/tui/widgets/mod.rs
+++ b/crates/agtop-cli/src/tui/widgets/mod.rs
@@ -8,6 +8,7 @@ pub mod dashboard_cost;
 pub mod dashboard_plan;
 pub mod dashboard_usage;
 pub mod info_tab;
+pub mod process_tab;
 pub mod quota_bar;
 pub mod quota_tab;
 pub mod session_table;

--- a/crates/agtop-cli/src/tui/widgets/mod.rs
+++ b/crates/agtop-cli/src/tui/widgets/mod.rs
@@ -16,8 +16,8 @@ pub mod state_display;
 
 /// Right-aligned key–value row used by Info and Process tabs.
 pub(super) fn kv_line(key: &'static str, value: String) -> ratatui::prelude::Line<'static> {
-    use ratatui::prelude::*;
     use crate::tui::theme as th;
+    use ratatui::prelude::*;
     Line::from(vec![
         Span::styled(format!("{key:>16}"), th::INFO_KEY),
         Span::raw("  "),

--- a/crates/agtop-cli/src/tui/widgets/mod.rs
+++ b/crates/agtop-cli/src/tui/widgets/mod.rs
@@ -13,3 +13,14 @@ pub mod quota_bar;
 pub mod quota_tab;
 pub mod session_table;
 pub mod state_display;
+
+/// Right-aligned key–value row used by Info and Process tabs.
+pub(super) fn kv_line(key: &'static str, value: String) -> ratatui::prelude::Line<'static> {
+    use ratatui::prelude::*;
+    use crate::tui::theme as th;
+    Line::from(vec![
+        Span::styled(format!("{key:>16}"), th::INFO_KEY),
+        Span::raw("  "),
+        Span::raw(value),
+    ])
+}

--- a/crates/agtop-cli/src/tui/widgets/process_tab.rs
+++ b/crates/agtop-cli/src/tui/widgets/process_tab.rs
@@ -43,9 +43,12 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
 
                 let cpu = fmt::format_percent(a.process_metrics.as_ref().map(|m| m.cpu_percent));
                 let mem = fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.memory_bytes));
-                let vsz = fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.virtual_memory_bytes));
-                let disk_r = fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.disk_read_bytes));
-                let disk_w = fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.disk_written_bytes));
+                let vsz =
+                    fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.virtual_memory_bytes));
+                let disk_r =
+                    fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.disk_read_bytes));
+                let disk_w =
+                    fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.disk_written_bytes));
 
                 let lines = vec![
                     super::kv_line("pid", pid_val),
@@ -59,10 +62,7 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
 
                 let inner = block.inner(area);
                 frame.render_widget(block, area);
-                frame.render_widget(
-                    Paragraph::new(lines).wrap(Wrap { trim: false }),
-                    inner,
-                );
+                frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
                 return;
             }
         },
@@ -70,4 +70,3 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
 
     frame.render_widget(body, area);
 }
-

--- a/crates/agtop-cli/src/tui/widgets/process_tab.rs
+++ b/crates/agtop-cli/src/tui/widgets/process_tab.rs
@@ -1,0 +1,92 @@
+//! "Process" tab: live OS resource metrics for the selected session.
+
+use ratatui::{
+    layout::Alignment,
+    prelude::*,
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+
+use crate::fmt;
+use crate::tui::app::App;
+use crate::tui::theme as th;
+use agtop_core::process::{Confidence, Liveness};
+
+pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let block = Block::default().borders(Borders::ALL).title(" Process ");
+
+    let body = match app.selected() {
+        None => Paragraph::new("(no session selected)")
+            .alignment(Alignment::Center)
+            .style(th::EMPTY_HINT)
+            .block(block),
+
+        Some((_, a)) => match a.pid {
+            None => Paragraph::new("(no live process for this session)")
+                .alignment(Alignment::Center)
+                .style(th::EMPTY_HINT)
+                .block(block),
+
+            Some(pid) => {
+                let liveness = match a.liveness {
+                    Some(Liveness::Live) => "live",
+                    Some(Liveness::Stopped) => "stopped",
+                    None => "-",
+                };
+                let pid_val = format!("{pid} ({liveness})");
+
+                let match_label = match a.match_confidence {
+                    Some(Confidence::High) => "fd",
+                    Some(Confidence::Medium) => "cwd+argv",
+                    None => "-",
+                };
+
+                let (cpu, mem, vsz, disk_r, disk_w) = if let Some(ref m) = a.process_metrics {
+                    (
+                        fmt::format_percent(Some(m.cpu_percent)),
+                        fmt::compact_opt(Some(m.memory_bytes)),
+                        fmt::compact_opt(Some(m.virtual_memory_bytes)),
+                        fmt::compact_opt(Some(m.disk_read_bytes)),
+                        fmt::compact_opt(Some(m.disk_written_bytes)),
+                    )
+                } else {
+                    (
+                        "-".into(),
+                        "-".into(),
+                        "-".into(),
+                        "-".into(),
+                        "-".into(),
+                    )
+                };
+
+                let lines = vec![
+                    kv_line("pid", pid_val),
+                    kv_line("match", match_label.to_string()),
+                    kv_line("cpu", cpu),
+                    kv_line("memory", mem),
+                    kv_line("virtual_memory", vsz),
+                    kv_line("disk_read", disk_r),
+                    kv_line("disk_written", disk_w),
+                ];
+
+                let outer_block = block;
+                let inner = outer_block.inner(area);
+                frame.render_widget(outer_block, area);
+                frame.render_widget(
+                    Paragraph::new(lines).wrap(Wrap { trim: false }),
+                    inner,
+                );
+                return;
+            }
+        },
+    };
+
+    frame.render_widget(body, area);
+}
+
+fn kv_line(key: &'static str, value: String) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("{key:>16}"), th::INFO_KEY),
+        Span::raw("  "),
+        Span::raw(value),
+    ])
+}

--- a/crates/agtop-cli/src/tui/widgets/process_tab.rs
+++ b/crates/agtop-cli/src/tui/widgets/process_tab.rs
@@ -11,6 +11,7 @@ use crate::tui::app::App;
 use crate::tui::theme as th;
 use agtop_core::process::{Confidence, Liveness};
 
+/// Render the Process tab into `area`, showing live OS metrics for the selected session.
 pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let block = Block::default().borders(Borders::ALL).title(" Process ");
 
@@ -40,23 +41,11 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
                     None => "-",
                 };
 
-                let (cpu, mem, vsz, disk_r, disk_w) = if let Some(ref m) = a.process_metrics {
-                    (
-                        fmt::format_percent(Some(m.cpu_percent)),
-                        fmt::compact_opt(Some(m.memory_bytes)),
-                        fmt::compact_opt(Some(m.virtual_memory_bytes)),
-                        fmt::compact_opt(Some(m.disk_read_bytes)),
-                        fmt::compact_opt(Some(m.disk_written_bytes)),
-                    )
-                } else {
-                    (
-                        "-".into(),
-                        "-".into(),
-                        "-".into(),
-                        "-".into(),
-                        "-".into(),
-                    )
-                };
+                let cpu = fmt::format_percent(a.process_metrics.as_ref().map(|m| m.cpu_percent));
+                let mem = fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.memory_bytes));
+                let vsz = fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.virtual_memory_bytes));
+                let disk_r = fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.disk_read_bytes));
+                let disk_w = fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.disk_written_bytes));
 
                 let lines = vec![
                     kv_line("pid", pid_val),
@@ -68,9 +57,8 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
                     kv_line("disk_written", disk_w),
                 ];
 
-                let outer_block = block;
-                let inner = outer_block.inner(area);
-                frame.render_widget(outer_block, area);
+                let inner = block.inner(area);
+                frame.render_widget(block, area);
                 frame.render_widget(
                     Paragraph::new(lines).wrap(Wrap { trim: false }),
                     inner,
@@ -84,9 +72,5 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
 }
 
 fn kv_line(key: &'static str, value: String) -> Line<'static> {
-    Line::from(vec![
-        Span::styled(format!("{key:>16}"), th::INFO_KEY),
-        Span::raw("  "),
-        Span::raw(value),
-    ])
+    super::kv_line(key, value)
 }

--- a/crates/agtop-cli/src/tui/widgets/process_tab.rs
+++ b/crates/agtop-cli/src/tui/widgets/process_tab.rs
@@ -48,13 +48,13 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 let disk_w = fmt::compact_opt(a.process_metrics.as_ref().map(|m| m.disk_written_bytes));
 
                 let lines = vec![
-                    kv_line("pid", pid_val),
-                    kv_line("match", match_label.to_string()),
-                    kv_line("cpu", cpu),
-                    kv_line("memory", mem),
-                    kv_line("virtual_memory", vsz),
-                    kv_line("disk_read", disk_r),
-                    kv_line("disk_written", disk_w),
+                    super::kv_line("pid", pid_val),
+                    super::kv_line("match", match_label.to_string()),
+                    super::kv_line("cpu", cpu),
+                    super::kv_line("memory", mem),
+                    super::kv_line("virtual_memory", vsz),
+                    super::kv_line("disk_read", disk_r),
+                    super::kv_line("disk_written", disk_w),
                 ];
 
                 let inner = block.inner(area);
@@ -71,6 +71,3 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, app: &App) {
     frame.render_widget(body, area);
 }
 
-fn kv_line(key: &'static str, value: String) -> Line<'static> {
-    super::kv_line(key, value)
-}

--- a/crates/agtop-cli/src/tui/widgets/session_table.rs
+++ b/crates/agtop-cli/src/tui/widgets/session_table.rs
@@ -373,6 +373,21 @@ fn row_for<'a>(
                 }
                 _ => "-".into(),
             }),
+            ColumnId::Cpu => Cell::from(crate::fmt::format_percent(
+                a.process_metrics.as_ref().map(|m| m.cpu_percent),
+            )),
+            ColumnId::Memory => Cell::from(crate::fmt::compact_opt(
+                a.process_metrics.as_ref().map(|m| m.memory_bytes),
+            )),
+            ColumnId::VirtualMemory => Cell::from(crate::fmt::compact_opt(
+                a.process_metrics.as_ref().map(|m| m.virtual_memory_bytes),
+            )),
+            ColumnId::DiskRead => Cell::from(crate::fmt::compact_opt(
+                a.process_metrics.as_ref().map(|m| m.disk_read_bytes),
+            )),
+            ColumnId::DiskWritten => Cell::from(crate::fmt::compact_opt(
+                a.process_metrics.as_ref().map(|m| m.disk_written_bytes),
+            )),
             // SubscriptionLogo is injected by visible() — rendered as empty for now.
             ColumnId::SubscriptionLogo => Cell::from(""),
         })

--- a/crates/agtop-core/src/clients/claude.rs
+++ b/crates/agtop-core/src/clients/claude.rs
@@ -556,6 +556,7 @@ fn analyze_claude_file(summary: &SessionSummary, plan: Plan) -> Result<SessionAn
         pid: None,
         liveness: None,
         match_confidence: None,
+        process_metrics: None,
     })
 }
 

--- a/crates/agtop-core/src/clients/codex.rs
+++ b/crates/agtop-core/src/clients/codex.rs
@@ -878,6 +878,7 @@ fn analyze_codex_file(summary: &SessionSummary, plan: Plan) -> Result<SessionAna
         pid: None,
         liveness: None,
         match_confidence: None,
+        process_metrics: None,
     })
 }
 

--- a/crates/agtop-core/src/clients/gemini_cli.rs
+++ b/crates/agtop-core/src/clients/gemini_cli.rs
@@ -245,6 +245,7 @@ impl Client for GeminiCliClient {
             pid: None,
             liveness: None,
             match_confidence: None,
+            process_metrics: None,
         })
     }
 }

--- a/crates/agtop-core/src/clients/opencode.rs
+++ b/crates/agtop-core/src/clients/opencode.rs
@@ -1418,6 +1418,7 @@ impl TurnAccumulator {
             pid: None,
             liveness: None,
             match_confidence: None,
+            process_metrics: None,
         })
     }
 }

--- a/crates/agtop-core/src/process/correlator.rs
+++ b/crates/agtop-core/src/process/correlator.rs
@@ -1057,7 +1057,11 @@ mod tests {
                 pid: 42,
                 parent_pid: None,
                 binary: "claude".to_string(),
-                argv: vec!["claude".to_string(), "--resume".to_string(), UUID_A.to_string()],
+                argv: vec![
+                    "claude".to_string(),
+                    "--resume".to_string(),
+                    UUID_A.to_string(),
+                ],
                 cwd: Some(std::path::PathBuf::from("/home/user/proj")),
                 start_time: Utc::now().timestamp() as u64,
                 metrics: Some(metrics.clone()),
@@ -1066,7 +1070,10 @@ mod tests {
         let fd_scanner = FakeFdScanner::default();
         let out = correlate(&scanner, &fd_scanner, &[session]);
         let info = out.get(UUID_A).expect("should have matched");
-        assert_eq!(info.metrics.as_ref().map(|m| m.disk_written_bytes), Some(40));
+        assert_eq!(
+            info.metrics.as_ref().map(|m| m.disk_written_bytes),
+            Some(40)
+        );
         assert_eq!(info.metrics.as_ref().map(|m| m.cpu_percent), Some(7.0));
     }
 
@@ -1094,11 +1101,20 @@ mod tests {
         };
         // fd_scanner returns the session transcript path for pid 99.
         let fd_scanner = FakeFdScanner {
-            map: [(99u32, vec![std::path::PathBuf::from(format!("/home/.claude/{UUID_A}.jsonl"))])].into(),
+            map: [(
+                99u32,
+                vec![std::path::PathBuf::from(format!(
+                    "/home/.claude/{UUID_A}.jsonl"
+                ))],
+            )]
+            .into(),
         };
         let out = correlate(&scanner, &fd_scanner, &[session]);
         let info = out.get(UUID_A).expect("should have matched via Tier B");
-        assert_eq!(info.metrics.as_ref().map(|m| m.disk_written_bytes), Some(400));
+        assert_eq!(
+            info.metrics.as_ref().map(|m| m.disk_written_bytes),
+            Some(400)
+        );
         assert_eq!(info.metrics.as_ref().map(|m| m.cpu_percent), Some(5.0));
     }
 
@@ -1134,7 +1150,10 @@ mod tests {
         let fd_scanner = FakeFdScanner::default();
         let out = correlate(&scanner, &fd_scanner, &[session]);
         let info = out.get(UUID_A).expect("should have matched via Tier C");
-        assert_eq!(info.metrics.as_ref().map(|m| m.disk_written_bytes), Some(444));
+        assert_eq!(
+            info.metrics.as_ref().map(|m| m.disk_written_bytes),
+            Some(444)
+        );
         assert_eq!(info.metrics.as_ref().map(|m| m.cpu_percent), Some(9.0));
     }
 }

--- a/crates/agtop-core/src/process/correlator.rs
+++ b/crates/agtop-core/src/process/correlator.rs
@@ -81,6 +81,7 @@ pub(crate) fn correlate(
                             liveness: Liveness::Live,
                             match_confidence: Confidence::High,
                             parent_pid: c.parent_pid,
+                            metrics: None,
                         },
                     );
                     used_pids.insert(c.pid);
@@ -160,6 +161,7 @@ pub(crate) fn correlate(
                     liveness: Liveness::Live,
                     match_confidence: Confidence::High,
                     parent_pid: c.parent_pid,
+                    metrics: None,
                 },
             );
             used_pids.insert(c.pid);
@@ -321,6 +323,7 @@ pub(crate) fn correlate(
                 liveness: Liveness::Live,
                 match_confidence: Confidence::Medium,
                 parent_pid: m.parent_pid,
+                metrics: None,
             },
         );
         used_pids.insert(m.pid);
@@ -942,6 +945,7 @@ mod tests {
                 liveness: Liveness::Live,
                 match_confidence: Confidence::High,
                 parent_pid: None,
+                metrics: None,
             },
         );
         out.insert(
@@ -951,6 +955,7 @@ mod tests {
                 liveness: Liveness::Live,
                 match_confidence: Confidence::High,
                 parent_pid: None,
+                metrics: None,
             },
         );
 

--- a/crates/agtop-core/src/process/correlator.rs
+++ b/crates/agtop-core/src/process/correlator.rs
@@ -33,7 +33,7 @@ use crate::process::argv_uuid::{extract_session_uuid, is_valid_uuid};
 use crate::process::fd::FdScanner;
 use crate::process::scanner::{Candidate, Scanner};
 use crate::process::transcript_paths::expected_binaries;
-use crate::process::{Confidence, Liveness, ProcessInfo};
+use crate::process::{Confidence, Liveness, ProcessInfo, ProcessMetrics};
 use crate::session::{ClientKind, SessionSummary};
 
 /// Run one correlation pass.
@@ -81,7 +81,7 @@ pub(crate) fn correlate(
                             liveness: Liveness::Live,
                             match_confidence: Confidence::High,
                             parent_pid: c.parent_pid,
-                            metrics: None,
+                            metrics: c.metrics.clone(),
                         },
                     );
                     used_pids.insert(c.pid);
@@ -161,7 +161,7 @@ pub(crate) fn correlate(
                     liveness: Liveness::Live,
                     match_confidence: Confidence::High,
                     parent_pid: c.parent_pid,
-                    metrics: None,
+                    metrics: c.metrics.clone(),
                 },
             );
             used_pids.insert(c.pid);
@@ -185,6 +185,7 @@ pub(crate) fn correlate(
         session: &'a SessionSummary,
         pid: u32,
         parent_pid: Option<u32>,
+        metrics: Option<ProcessMetrics>,
     }
     let mut score_matches: Vec<ScoreMatch<'_>> = Vec::new();
 
@@ -263,6 +264,7 @@ pub(crate) fn correlate(
                 session,
                 pid: c.pid,
                 parent_pid: c.parent_pid,
+                metrics: c.metrics.clone(),
             });
         }
     }
@@ -323,7 +325,7 @@ pub(crate) fn correlate(
                 liveness: Liveness::Live,
                 match_confidence: Confidence::Medium,
                 parent_pid: m.parent_pid,
-                metrics: None,
+                metrics: m.metrics.clone(),
             },
         );
         used_pids.insert(m.pid);
@@ -493,6 +495,7 @@ mod tests {
             argv: vec![binary.into()],
             cwd: Some(PathBuf::from(cwd)),
             start_time: 1700000000,
+            metrics: None,
         }
     }
 
@@ -1037,5 +1040,34 @@ mod tests {
         assert!(find_uuids_in("/no/uuid/here.txt").is_empty());
         assert!(find_uuids_in("").is_empty());
         assert!(find_uuids_in("short").is_empty());
+    }
+
+    #[test]
+    fn tier_a_copies_candidate_metrics_to_process_info() {
+        use crate::process::ProcessMetrics;
+        let session = claude_session(UUID_A, &format!("/tmp/{UUID_A}.jsonl"));
+        let metrics = ProcessMetrics {
+            cpu_percent: 7.0,
+            memory_bytes: 10,
+            virtual_memory_bytes: 20,
+            disk_read_bytes: 30,
+            disk_written_bytes: 40,
+        };
+        let scanner = FakeScanner {
+            processes: vec![Candidate {
+                pid: 42,
+                parent_pid: None,
+                binary: "claude".to_string(),
+                argv: vec!["claude".to_string(), "--resume".to_string(), UUID_A.to_string()],
+                cwd: Some(std::path::PathBuf::from("/home/user/proj")),
+                start_time: Utc::now().timestamp() as u64,
+                metrics: Some(metrics.clone()),
+            }],
+        };
+        let fd_scanner = FakeFdScanner::default();
+        let out = correlate(&scanner, &fd_scanner, &[session]);
+        let info = out.get(UUID_A).expect("should have matched");
+        assert_eq!(info.metrics.as_ref().map(|m| m.disk_written_bytes), Some(40));
+        assert_eq!(info.metrics.as_ref().map(|m| m.cpu_percent), Some(7.0));
     }
 }

--- a/crates/agtop-core/src/process/correlator.rs
+++ b/crates/agtop-core/src/process/correlator.rs
@@ -1044,7 +1044,6 @@ mod tests {
 
     #[test]
     fn tier_a_copies_candidate_metrics_to_process_info() {
-        use crate::process::ProcessMetrics;
         let session = claude_session(UUID_A, &format!("/tmp/{UUID_A}.jsonl"));
         let metrics = ProcessMetrics {
             cpu_percent: 7.0,
@@ -1069,5 +1068,73 @@ mod tests {
         let info = out.get(UUID_A).expect("should have matched");
         assert_eq!(info.metrics.as_ref().map(|m| m.disk_written_bytes), Some(40));
         assert_eq!(info.metrics.as_ref().map(|m| m.cpu_percent), Some(7.0));
+    }
+
+    #[test]
+    fn tier_b_copies_candidate_metrics_to_process_info() {
+        let session = claude_session(UUID_A, &format!("/tmp/{UUID_A}.jsonl"));
+        let metrics = ProcessMetrics {
+            cpu_percent: 5.0,
+            memory_bytes: 100,
+            virtual_memory_bytes: 200,
+            disk_read_bytes: 300,
+            disk_written_bytes: 400,
+        };
+        // Candidate has a different argv so Tier A won't match.
+        let scanner = FakeScanner {
+            processes: vec![Candidate {
+                pid: 99,
+                parent_pid: None,
+                binary: "claude".to_string(),
+                argv: vec!["claude".to_string()],
+                cwd: Some(std::path::PathBuf::from("/home/user/proj")),
+                start_time: Utc::now().timestamp() as u64,
+                metrics: Some(metrics.clone()),
+            }],
+        };
+        // fd_scanner returns the session transcript path for pid 99.
+        let fd_scanner = FakeFdScanner {
+            map: [(99u32, vec![std::path::PathBuf::from(format!("/home/.claude/{UUID_A}.jsonl"))])].into(),
+        };
+        let out = correlate(&scanner, &fd_scanner, &[session]);
+        let info = out.get(UUID_A).expect("should have matched via Tier B");
+        assert_eq!(info.metrics.as_ref().map(|m| m.disk_written_bytes), Some(400));
+        assert_eq!(info.metrics.as_ref().map(|m| m.cpu_percent), Some(5.0));
+    }
+
+    #[test]
+    fn tier_c_copies_candidate_metrics_to_process_info() {
+        // Session needs a cwd so the cwd hard gate passes.
+        let mut session = claude_session(UUID_A, &format!("/tmp/{UUID_A}.jsonl"));
+        session.cwd = Some("/home/user/proj".into());
+        // started_at must be set so the time window criterion can fire.
+        let start = Utc::now() - Duration::seconds(10);
+        session.started_at = Some(start);
+        session.last_active = Some(Utc::now());
+
+        let metrics = ProcessMetrics {
+            cpu_percent: 9.0,
+            memory_bytes: 111,
+            virtual_memory_bytes: 222,
+            disk_read_bytes: 333,
+            disk_written_bytes: 444,
+        };
+        // Binary matches, cwd matches, start_time inside window => score 3.
+        let scanner = FakeScanner {
+            processes: vec![Candidate {
+                pid: 77,
+                parent_pid: None,
+                binary: "claude".to_string(),
+                argv: vec!["claude".to_string()],
+                cwd: Some(std::path::PathBuf::from("/home/user/proj")),
+                start_time: start.timestamp() as u64 + 1,
+                metrics: Some(metrics.clone()),
+            }],
+        };
+        let fd_scanner = FakeFdScanner::default();
+        let out = correlate(&scanner, &fd_scanner, &[session]);
+        let info = out.get(UUID_A).expect("should have matched via Tier C");
+        assert_eq!(info.metrics.as_ref().map(|m| m.disk_written_bytes), Some(444));
+        assert_eq!(info.metrics.as_ref().map(|m| m.cpu_percent), Some(9.0));
     }
 }

--- a/crates/agtop-core/src/process/fd.rs
+++ b/crates/agtop-core/src/process/fd.rs
@@ -106,6 +106,7 @@ pub(crate) mod tests {
     use std::collections::HashMap;
 
     /// Test fake backed by an injected map of pid -> paths.
+    #[derive(Default)]
     pub(crate) struct FakeFdScanner {
         pub map: HashMap<u32, Vec<PathBuf>>,
     }

--- a/crates/agtop-core/src/process/mod.rs
+++ b/crates/agtop-core/src/process/mod.rs
@@ -266,7 +266,10 @@ mod lifecycle_tests {
         assert_eq!(p.pid, Some(4242));
         assert_eq!(p.liveness, Some(Liveness::Live));
         assert_eq!(p.match_confidence, Some(Confidence::High));
-        assert_eq!(p.process_metrics.as_ref().map(|m| m.cpu_percent), Some(FAKE_CPU));
+        assert_eq!(
+            p.process_metrics.as_ref().map(|m| m.cpu_percent),
+            Some(FAKE_CPU)
+        );
         for child in &p.children {
             assert_eq!(
                 child.pid,

--- a/crates/agtop-core/src/process/mod.rs
+++ b/crates/agtop-core/src/process/mod.rs
@@ -47,10 +47,15 @@ pub enum Liveness {
 /// Live OS resource metrics for a matched process.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProcessMetrics {
+    /// Instantaneous CPU usage as a percentage (0.0–100.0 per core, as reported by sysinfo).
     pub cpu_percent: f32,
+    /// Resident set size in bytes.
     pub memory_bytes: u64,
+    /// Virtual memory size in bytes.
     pub virtual_memory_bytes: u64,
+    /// Cumulative bytes read from disk since process start.
     pub disk_read_bytes: u64,
+    /// Cumulative bytes written to disk since process start.
     pub disk_written_bytes: u64,
 }
 
@@ -61,6 +66,7 @@ pub struct ProcessInfo {
     pub liveness: Liveness,
     pub match_confidence: Confidence,
     pub parent_pid: Option<u32>,
+    /// Live resource metrics; `None` when not yet sampled or process is stopped.
     pub metrics: Option<ProcessMetrics>,
 }
 
@@ -165,7 +171,8 @@ pub fn attach_process_info(
             a.liveness = Some(info.liveness);
             a.match_confidence = Some(info.match_confidence);
             a.process_metrics = info.metrics.clone();
-            // Propagate to subagents: same OS process.
+            // Note: propagation is one level deep only. Subagents run in-process
+            // within their parent CLI, so there is no deeper nesting in practice.
             for child in &mut a.children {
                 child.pid = Some(info.pid);
                 child.liveness = Some(info.liveness);
@@ -225,6 +232,12 @@ mod lifecycle_tests {
         // PID of their own. After correlation we copy the parent's
         // match (PID + liveness + confidence) onto every child so the
         // TUI can show the actual OS process.
+        const FAKE_CPU: f32 = 12.5;
+        const FAKE_MEM_BYTES: u64 = 64 * 1024 * 1024;
+        const FAKE_VMEM_BYTES: u64 = 512 * 1024 * 1024;
+        const FAKE_DISK_READ: u64 = 1_024;
+        const FAKE_DISK_WRITE: u64 = 2_048;
+
         let mut parent = analysis("parent-1");
         parent.children = vec![analysis("child-1"), analysis("child-2")];
         let mut analyses = vec![parent];
@@ -238,11 +251,11 @@ mod lifecycle_tests {
                 match_confidence: Confidence::High,
                 parent_pid: Some(1),
                 metrics: Some(ProcessMetrics {
-                    cpu_percent: 12.5,
-                    memory_bytes: 64 * 1024 * 1024,
-                    virtual_memory_bytes: 512 * 1024 * 1024,
-                    disk_read_bytes: 1_024,
-                    disk_written_bytes: 2_048,
+                    cpu_percent: FAKE_CPU,
+                    memory_bytes: FAKE_MEM_BYTES,
+                    virtual_memory_bytes: FAKE_VMEM_BYTES,
+                    disk_read_bytes: FAKE_DISK_READ,
+                    disk_written_bytes: FAKE_DISK_WRITE,
                 }),
             },
         );
@@ -253,7 +266,7 @@ mod lifecycle_tests {
         assert_eq!(p.pid, Some(4242));
         assert_eq!(p.liveness, Some(Liveness::Live));
         assert_eq!(p.match_confidence, Some(Confidence::High));
-        assert_eq!(p.process_metrics.as_ref().map(|m| m.cpu_percent), Some(12.5));
+        assert_eq!(p.process_metrics.as_ref().map(|m| m.cpu_percent), Some(FAKE_CPU));
         for child in &p.children {
             assert_eq!(
                 child.pid,
@@ -265,7 +278,7 @@ mod lifecycle_tests {
             assert_eq!(child.match_confidence, Some(Confidence::High));
             assert_eq!(
                 child.process_metrics.as_ref().map(|m| m.memory_bytes),
-                Some(64 * 1024 * 1024)
+                Some(FAKE_MEM_BYTES)
             );
         }
     }

--- a/crates/agtop-core/src/process/mod.rs
+++ b/crates/agtop-core/src/process/mod.rs
@@ -316,6 +316,7 @@ mod lifecycle_tests {
                 argv: vec!["claude".into()],
                 cwd: None,
                 start_time: 1700000000,
+                metrics: None,
             }],
         });
         let mut fd_map = std::collections::HashMap::new();

--- a/crates/agtop-core/src/process/mod.rs
+++ b/crates/agtop-core/src/process/mod.rs
@@ -44,6 +44,16 @@ pub enum Liveness {
     Stopped,
 }
 
+/// Live OS resource metrics for a matched process.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProcessMetrics {
+    pub cpu_percent: f32,
+    pub memory_bytes: u64,
+    pub virtual_memory_bytes: u64,
+    pub disk_read_bytes: u64,
+    pub disk_written_bytes: u64,
+}
+
 /// Per-session OS-process information attached after correlation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcessInfo {
@@ -51,6 +61,7 @@ pub struct ProcessInfo {
     pub liveness: Liveness,
     pub match_confidence: Confidence,
     pub parent_pid: Option<u32>,
+    pub metrics: Option<ProcessMetrics>,
 }
 
 /// Correlates a set of sessions to currently-running OS processes.
@@ -120,6 +131,7 @@ impl ProcessCorrelator {
                         liveness: Liveness::Stopped,
                         match_confidence: prior_info.match_confidence,
                         parent_pid: prior_info.parent_pid,
+                        metrics: None,
                     },
                 );
                 new_drop_next.insert(sid.clone());
@@ -152,11 +164,13 @@ pub fn attach_process_info(
             a.pid = Some(info.pid);
             a.liveness = Some(info.liveness);
             a.match_confidence = Some(info.match_confidence);
+            a.process_metrics = info.metrics.clone();
             // Propagate to subagents: same OS process.
             for child in &mut a.children {
                 child.pid = Some(info.pid);
                 child.liveness = Some(info.liveness);
                 child.match_confidence = Some(info.match_confidence);
+                child.process_metrics = info.metrics.clone();
             }
         }
     }
@@ -223,6 +237,13 @@ mod lifecycle_tests {
                 liveness: Liveness::Live,
                 match_confidence: Confidence::High,
                 parent_pid: Some(1),
+                metrics: Some(ProcessMetrics {
+                    cpu_percent: 12.5,
+                    memory_bytes: 64 * 1024 * 1024,
+                    virtual_memory_bytes: 512 * 1024 * 1024,
+                    disk_read_bytes: 1_024,
+                    disk_written_bytes: 2_048,
+                }),
             },
         );
 
@@ -232,6 +253,7 @@ mod lifecycle_tests {
         assert_eq!(p.pid, Some(4242));
         assert_eq!(p.liveness, Some(Liveness::Live));
         assert_eq!(p.match_confidence, Some(Confidence::High));
+        assert_eq!(p.process_metrics.as_ref().map(|m| m.cpu_percent), Some(12.5));
         for child in &p.children {
             assert_eq!(
                 child.pid,
@@ -241,6 +263,10 @@ mod lifecycle_tests {
             );
             assert_eq!(child.liveness, Some(Liveness::Live));
             assert_eq!(child.match_confidence, Some(Confidence::High));
+            assert_eq!(
+                child.process_metrics.as_ref().map(|m| m.memory_bytes),
+                Some(64 * 1024 * 1024)
+            );
         }
     }
 
@@ -294,6 +320,7 @@ mod lifecycle_tests {
         });
         let second = c.snapshot(&sessions);
         assert_eq!(second.get(SID).map(|i| i.liveness), Some(Liveness::Stopped));
+        assert!(second.get(SID).and_then(|i| i.metrics.as_ref()).is_none());
 
         // Cycle 3: dropped.
         let third = c.snapshot(&sessions);

--- a/crates/agtop-core/src/process/scanner.rs
+++ b/crates/agtop-core/src/process/scanner.rs
@@ -2,9 +2,11 @@
 
 use std::path::PathBuf;
 
+use crate::process::ProcessMetrics;
+
 /// One candidate process that might be running an agent CLI.
 #[allow(dead_code)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Candidate {
     pub pid: u32,
     pub parent_pid: Option<u32>,
@@ -16,6 +18,9 @@ pub(crate) struct Candidate {
     pub cwd: Option<PathBuf>,
     /// Process start time, unix epoch seconds.
     pub start_time: u64,
+    /// Live resource metrics sampled when the candidate was enumerated.
+    /// `None` on `FakeScanner` fixtures unless a test explicitly sets it.
+    pub metrics: Option<ProcessMetrics>,
 }
 
 /// True if `needle` appears in `haystack` bounded on both sides by either
@@ -206,6 +211,14 @@ impl Scanner for SysinfoScanner {
             } else {
                 raw_binary
             };
+            let disk = proc.disk_usage();
+            let metrics = Some(ProcessMetrics {
+                cpu_percent: proc.cpu_usage(),
+                memory_bytes: proc.memory(),
+                virtual_memory_bytes: proc.virtual_memory(),
+                disk_read_bytes: disk.total_read_bytes,
+                disk_written_bytes: disk.total_written_bytes,
+            });
             self.candidates.push(Candidate {
                 pid: pid.as_u32(),
                 parent_pid: proc.parent().map(|p| p.as_u32()),
@@ -213,6 +226,7 @@ impl Scanner for SysinfoScanner {
                 argv,
                 cwd: proc.cwd().map(|p| p.to_path_buf()),
                 start_time: proc.start_time(),
+                metrics,
             });
         }
     }
@@ -249,6 +263,7 @@ pub(crate) mod tests {
                 argv: vec!["claude".to_string()],
                 cwd: Some(PathBuf::from("/home/test")),
                 start_time: 1700000000,
+                metrics: None,
             }],
         };
         s.refresh();

--- a/crates/agtop-core/src/process/scanner.rs
+++ b/crates/agtop-core/src/process/scanner.rs
@@ -19,7 +19,7 @@ pub(crate) struct Candidate {
     /// Process start time, unix epoch seconds.
     pub start_time: u64,
     /// Live resource metrics sampled when the candidate was enumerated.
-    /// `None` on `FakeScanner` fixtures unless a test explicitly sets it.
+    /// `None` if the OS could not provide the data for this process.
     pub metrics: Option<ProcessMetrics>,
 }
 
@@ -72,9 +72,9 @@ pub(crate) struct SysinfoScanner {
 #[allow(dead_code)]
 impl SysinfoScanner {
     pub(crate) fn new() -> Self {
-        // `new_with_specifics(ProcessRefreshKind::everything())` is heavier
-        // than we need — we don't want disk IO / network stats. Start
-        // minimal and refresh just the process list on each call.
+        // `new_with_specifics(ProcessRefreshKind::everything())` is called on
+        // each refresh (not here) to get full metrics including disk I/O.
+        // Initialize with an empty system; the heavy work happens in refresh().
         let system = sysinfo::System::new();
         Self {
             system,

--- a/crates/agtop-core/src/session.rs
+++ b/crates/agtop-core/src/session.rs
@@ -239,6 +239,10 @@ pub struct SessionAnalysis {
     /// How we matched the PID. `None` when no match.
     #[serde(default)]
     pub match_confidence: Option<crate::process::Confidence>,
+    /// Live OS resource metrics for the matched process. `None` when no
+    /// process is matched or the process has stopped.
+    #[serde(default)]
+    pub process_metrics: Option<crate::process::ProcessMetrics>,
 }
 
 impl SessionAnalysis {
@@ -277,6 +281,7 @@ impl SessionAnalysis {
             pid: None,
             liveness: None,
             match_confidence: None,
+            process_metrics: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `ProcessMetrics` struct carrying live CPU usage, resident memory, virtual memory, and cumulative disk counters sampled from sysinfo on each refresh cycle.
- The existing PID-correlation path (argv, fd, and score tiers) now copies candidate metrics into `ProcessInfo` and propagates them to `SessionAnalysis::process_metrics` for all output modes.
- Exposes metrics in `--json` output, adds PID/CPU/MEM columns to `--list` table, and adds five new configurable TUI columns (`CPU`, `MEM`, `VSZ`, `DISK R`, `DISK W`) — `CPU` and `MEM` visible by default.
- Adds a dedicated **Process** tab (between Info and Cost) showing PID, liveness, match confidence, CPU, memory, virtual memory, disk read, and disk written — giving process metrics their own panel instead of crowding the Info tab.

## Details

- **Core (`agtop-core`):** `ProcessMetrics` type on `ProcessInfo`; `SessionAnalysis::process_metrics`; propagation to subagent children; stopped frames clear metrics to `None`.
- **Scanner:** `SysinfoScanner::refresh` reads `cpu_usage()`, `memory()`, `virtual_memory()`, `disk_usage()` per candidate.
- **Correlator:** All three tiers (argv/fd/score) copy `c.metrics.clone()` into `ProcessInfo`. Tier-C `ScoreMatch` carries metrics through the recency-dedup pass.
- **CLI:** `--json` includes `process_metrics` field; `--list` and `--watch` run PID correlation (watch hoists the `ProcessCorrelator` outside the loop to preserve stopped-frame state); `render_table` adds PID, CPU, MEM columns.
- **TUI:** `ColumnId` gains five variants; `ColumnConfig::normalize` appends missing columns to old persisted configs; `default_visible` helper shared across default and normalize paths. New **Process tab** (`process_tab.rs`) renders all metrics via shared `kv_line` helper in `widgets/mod.rs`.

## Test Plan

- 517 tests pass (`cargo test`)
- `cargo fmt --check` clean
- `cargo clippy -- -D warnings` clean
- Tier A, B, and C metrics propagation each have dedicated unit tests
- Old-config normalization test verifies new columns are appended correctly
- `process_tab_renders_without_panic` smoke test verifies the new tab renders