### PR TITLE
feat(tui): improve layout on wide terminals

### DIFF
--- a/crates/agtop-cli/src/tui/column_config.rs
+++ b/crates/agtop-cli/src/tui/column_config.rs
@@ -271,6 +271,7 @@ pub fn default_visible_v2() -> Vec<ColumnId> {
         ColumnId::DiskReadRate,
         ColumnId::DiskWriteRate,
         ColumnId::Tokens,
+        ColumnId::Context,
         ColumnId::Cost,
         ColumnId::Project,
         ColumnId::SessionName,

--- a/crates/agtop-cli/src/tui/column_config.rs
+++ b/crates/agtop-cli/src/tui/column_config.rs
@@ -11,7 +11,7 @@ use crate::tui::app::{SortColumn, SortDir};
 use agtop_core::ClientKind;
 
 /// All column identifiers in the session table.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ColumnId {
     #[serde(alias = "provider")]

--- a/crates/agtop-cli/src/tui/screens/dashboard/info_summary.rs
+++ b/crates/agtop-cli/src/tui/screens/dashboard/info_summary.rs
@@ -12,7 +12,7 @@ use ratatui::{
 
 use agtop_core::session::{ClientKind, SessionAnalysis, SessionState};
 
-use super::info_format::{human_tokens, money_summary, truncate_to};
+use super::info_format::{human_bytes, human_tokens, money_summary, truncate_to};
 use crate::tui::theme_v2::{client_palette, Theme};
 use crate::tui::widgets::{icon::Icon, state_style};
 
@@ -64,10 +64,10 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, m: &SummaryModel<'_>, theme: &T
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(4),
-            Constraint::Length(5),
-            Constraint::Length(2),
-            Constraint::Min(6),
+            Constraint::Length(5), // hero: project, cwd, started, title, pills
+            Constraint::Length(7), // status: header, state, session, usage, context, disk, spacer
+            Constraint::Length(2), // activity sparkline
+            Constraint::Min(6),    // recent messages
         ])
         .split(area);
     render_hero(frame, layout[0], m, theme);
@@ -122,6 +122,9 @@ fn render_hero(frame: &mut Frame<'_>, area: Rect, m: &SummaryModel<'_>, theme: &
     let state_label = state_style::label_for(m.state);
     let state_color_style = state_color_style(m.state, theme);
 
+    let session_title = m.analysis.summary.session_title.as_deref().unwrap_or("");
+    let tag = Icon::Tag.render(m.nerd_font);
+
     let mut lines = vec![
         Line::from(vec![
             Span::styled(
@@ -141,6 +144,18 @@ fn render_hero(frame: &mut Frame<'_>, area: Rect, m: &SummaryModel<'_>, theme: &
             Span::styled(format!("{clock} "), Style::default().fg(theme.fg_muted)),
             Span::styled(started_str, Style::default().fg(theme.fg_muted)),
         ]),
+        // Session title row — empty line when no title is available.
+        if session_title.is_empty() {
+            Line::from("")
+        } else {
+            Line::from(vec![
+                Span::styled(format!("{tag} "), Style::default().fg(theme.fg_muted)),
+                Span::styled(
+                    truncate_to(session_title, area.width.saturating_sub(4) as usize),
+                    Style::default().fg(theme.fg_default),
+                ),
+            ])
+        },
         Line::from(vec![
             pill(m.client_label, title_color, theme),
             Span::raw(" "),
@@ -157,7 +172,7 @@ fn render_hero(frame: &mut Frame<'_>, area: Rect, m: &SummaryModel<'_>, theme: &
             ),
         ]),
     ];
-    while lines.len() < 4 {
+    while lines.len() < 5 {
         lines.push(Line::from(""));
     }
     frame.render_widget(Paragraph::new(lines), area);
@@ -196,6 +211,34 @@ fn render_status(frame: &mut Frame<'_>, area: Rect, m: &SummaryModel<'_>, theme:
         "Standalone".to_string()
     };
     let action = m.analysis.current_action.as_deref().unwrap_or("");
+
+    // Context usage row value.
+    let context_str = match (
+        m.analysis.context_used_pct,
+        m.analysis.context_used_tokens,
+        m.analysis.context_window,
+    ) {
+        (Some(pct), Some(used), Some(win)) => {
+            format!("{:.0}%  {} / {}", pct, human_tokens(used), human_tokens(win))
+        }
+        (Some(pct), _, _) => format!("{:.0}%", pct),
+        _ => "—".to_string(),
+    };
+
+    // Disk I/O row value (cumulative bytes since process start).
+    let disk_str = m
+        .analysis
+        .process_metrics
+        .as_ref()
+        .map(|pm| {
+            format!(
+                "R: {}   W: {}",
+                human_bytes(pm.disk_read_bytes),
+                human_bytes(pm.disk_written_bytes),
+            )
+        })
+        .unwrap_or_else(|| "—".to_string());
+
     let lines = vec![
         Line::from(vec![
             Span::styled(" Status ", Style::default().fg(theme.fg_muted)),
@@ -240,6 +283,14 @@ fn render_status(frame: &mut Frame<'_>, area: Rect, m: &SummaryModel<'_>, theme:
                 format!("{} agent turns", agent_turns),
                 Style::default().fg(theme.fg_default),
             ),
+        ]),
+        Line::from(vec![
+            Span::styled("Context  ", Style::default().fg(theme.fg_muted)),
+            Span::styled(context_str, Style::default().fg(theme.fg_default)),
+        ]),
+        Line::from(vec![
+            Span::styled("Disk     ", Style::default().fg(theme.fg_muted)),
+            Span::styled(disk_str, Style::default().fg(theme.fg_default)),
         ]),
         Line::from(""),
     ];

--- a/crates/agtop-cli/src/tui/screens/dashboard/quota.rs
+++ b/crates/agtop-cli/src/tui/screens/dashboard/quota.rs
@@ -335,25 +335,52 @@ impl QuotaPanel {
         // Reserve 1 row for overflow indicators if needed.
         let view_h = inner_h.saturating_sub(1).max(1);
 
-        if area.width > 80 && self.cards.len() >= 2 {
-            // 2-column layout.
+        // Determine column count based on available width and card count.
+        // >140 wide with 3+ cards → 3 columns; >80 wide with 2+ cards → 2
+        // columns; otherwise single column.
+        let n_cols = if area.width > 140 && self.cards.len() >= 3 {
+            3usize
+        } else if area.width > 80 && self.cards.len() >= 2 {
+            2
+        } else {
+            1
+        };
+
+        if n_cols > 1 {
             use ratatui::layout::{Constraint, Direction, Layout};
+            // Build equal-percentage column constraints.
+            let col_pct = (100 / n_cols) as u16;
+            let remainder = 100u16 - col_pct * n_cols as u16;
+            let constraints: Vec<Constraint> = (0..n_cols)
+                .map(|i| {
+                    // Give any leftover percentage to the last column.
+                    Constraint::Percentage(col_pct + if i == n_cols - 1 { remainder } else { 0 })
+                })
+                .collect();
+
             let cols = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .constraints(constraints)
                 .split(inner);
 
-            let mid = self.cards.len().div_ceil(2);
-            let left_lines: Vec<Line<'static>> = self.cards[..mid]
-                .iter()
-                .flat_map(|c| build_card_lines(c, label_width, theme))
-                .collect();
-            let right_lines: Vec<Line<'static>> = self.cards[mid..]
-                .iter()
-                .flat_map(|c| build_card_lines(c, label_width, theme))
+            // Distribute cards sequentially across columns.
+            let chunk = self.cards.len().div_ceil(n_cols);
+            let col_card_lines: Vec<Vec<Line<'static>>> = (0..n_cols)
+                .map(|ci| {
+                    let start = ci * chunk;
+                    let end = ((ci + 1) * chunk).min(self.cards.len());
+                    if start >= self.cards.len() {
+                        Vec::new()
+                    } else {
+                        self.cards[start..end]
+                            .iter()
+                            .flat_map(|c| build_card_lines(c, label_width, theme))
+                            .collect()
+                    }
+                })
                 .collect();
 
-            let total = left_lines.len().max(right_lines.len());
+            let total = col_card_lines.iter().map(|l| l.len()).max().unwrap_or(0);
             let offset = self.scroll_offset.min(total.saturating_sub(view_h));
 
             let overflow_below = total.saturating_sub(offset + view_h);
@@ -366,7 +393,7 @@ impl QuotaPanel {
                 frame.render_widget(Paragraph::new(hint), hint_rect);
             }
 
-            let mut render_col = |lines: Vec<Line<'static>>, col_rect: Rect| {
+            for (ci, lines) in col_card_lines.into_iter().enumerate() {
                 let mut visible: Vec<Line<'static>> =
                     lines.into_iter().skip(offset).take(view_h).collect();
                 if offset > 0 && visible.len() == view_h {
@@ -379,11 +406,8 @@ impl QuotaPanel {
                     );
                     visible.truncate(view_h);
                 }
-                frame.render_widget(Paragraph::new(visible), col_rect);
-            };
-
-            render_col(left_lines, cols[0]);
-            render_col(right_lines, cols[1]);
+                frame.render_widget(Paragraph::new(visible), cols[ci]);
+            }
         } else {
             // Single-column layout.
             let all_lines: Vec<Line<'static>> = self

--- a/crates/agtop-cli/src/tui/screens/dashboard/sessions.rs
+++ b/crates/agtop-cli/src/tui/screens/dashboard/sessions.rs
@@ -299,6 +299,12 @@ impl SessionsTable {
                     .clone()
                     .unwrap_or_default(),
             ),
+            ColumnId::Context => Cell::from(
+                row.analysis
+                    .context_used_pct
+                    .map(|pct| format!("{:.0}%", pct))
+                    .unwrap_or_else(|| "—".into()),
+            ),
             // Defaults for anything else.
             _ => Cell::from(""),
         }
@@ -571,10 +577,15 @@ fn width_for(col: ColumnId) -> Constraint {
         ColumnId::Model => Constraint::Length(20),
         ColumnId::Cpu => Constraint::Length(5),
         ColumnId::Memory => Constraint::Length(6),
-        ColumnId::Tokens => Constraint::Length(8),
-        ColumnId::Cost => Constraint::Length(7),
-        ColumnId::Project => Constraint::Min(12),
-        ColumnId::SessionName => Constraint::Min(14),
+            ColumnId::DiskReadRate => Constraint::Length(8),
+            ColumnId::DiskWriteRate => Constraint::Length(8),
+            ColumnId::Tokens => Constraint::Length(8),
+            ColumnId::Context => Constraint::Length(8),
+            ColumnId::Cost => Constraint::Length(7),
+            // Cap project and session-name so they don't stretch infinitely on
+            // wide terminals. Min(N) ensures the column is always at least N wide.
+            ColumnId::Project => Constraint::Max(25),
+            ColumnId::SessionName => Constraint::Max(40),
         _ => Constraint::Length(8),
     }
 }

--- a/crates/agtop-cli/src/tui/screens/dashboard/sessions.rs
+++ b/crates/agtop-cli/src/tui/screens/dashboard/sessions.rs
@@ -18,7 +18,7 @@ use crate::tui::input::AppEvent;
 use crate::tui::msg::Msg;
 
 use crate::tui::animation::PulseClock;
-use crate::tui::column_config::{self, ColumnId};
+use crate::tui::column_config::ColumnId;
 use crate::tui::theme_v2::{client_palette, Theme};
 use crate::tui::widgets::{sparkline_braille, state_dot, state_style};
 
@@ -99,16 +99,24 @@ impl Default for SessionsTable {
 impl SessionsTable {
     pub fn render(&mut self, frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
         self.table_area = area;
-        // Map columns from default_visible into column constraints + header strings.
-        let columns = column_config::default_visible_v2();
+        // Build the visible column list, dropping low-priority columns when
+        // the terminal is too narrow to fit everything with minimum widths.
+        // `show_activity` is false when the ACTIVITY sparkline itself is
+        // dropped (independently of the CLIENT column) to save 9 chars (8 +
+        // 1 spacing).
+        let (columns, show_activity) = visible_columns_for_width(area.width);
 
-        // Insertion point for ACTIVITY sparkline: after CLIENT. (Previously
-        // inserted after ACTION, but ACTION was removed from the default view.)
-        // Falls back to ACTION if a user re-enables it.
-        let activity_after = columns
-            .iter()
-            .position(|c| *c == ColumnId::Action)
-            .or_else(|| columns.iter().position(|c| *c == ColumnId::Client));
+        // Insertion point for ACTIVITY sparkline: after CLIENT (if active),
+        // falling back to ACTION. When `show_activity` is false the insertion
+        // point is computed but the sparkline cell is never actually added.
+        let activity_after = if show_activity {
+            columns
+                .iter()
+                .position(|c| *c == ColumnId::Action)
+                .or_else(|| columns.iter().position(|c| *c == ColumnId::Client))
+        } else {
+            None
+        };
 
         let mut header_cells: Vec<Cell> = Vec::with_capacity(columns.len() + 3);
         // State dot column has no header label.
@@ -139,12 +147,26 @@ impl SessionsTable {
             .map(|sr| self.render_row(sr, &columns, activity_after, theme))
             .collect();
 
+        // Build constraints. PROJECT and NAME widths are computed from the
+        // slack left after all fixed-width columns are accounted for:
+        //   - PROJECT: clamped to [PROJECT_MIN, PROJECT_MAX]
+        //   - NAME: at least NAME_MIN, takes all remaining slack (no upper cap)
+        let project_name_constraints =
+            project_name_constraints(&columns, activity_after, area.width);
+
         let mut constraints: Vec<Constraint> = Vec::with_capacity(columns.len() + 2);
-        // State-dot column: 5 cells wide. depth=0 needs 2 (▶ + space) + dot + space;
-        // depth=1 needs 4 for the tree glyph (`├── ` / `└── `) + dot.
+        // State-dot column: 5 cells wide.
         constraints.push(Constraint::Length(5));
         for (i, c) in columns.iter().enumerate() {
-            constraints.push(width_for(*c));
+            match c {
+                ColumnId::Project => {
+                    constraints.push(project_name_constraints.0);
+                }
+                ColumnId::SessionName => {
+                    constraints.push(project_name_constraints.1);
+                }
+                _ => constraints.push(fixed_width_for(*c)),
+            }
             if Some(i) == activity_after {
                 constraints.push(Constraint::Length(8)); // ACTIVITY sparkline
             }
@@ -567,7 +589,14 @@ impl SessionsTable {
     }
 }
 
-fn width_for(col: ColumnId) -> Constraint {
+/// Minimum and maximum widths for PROJECT and NAME columns.
+const PROJECT_MIN: u16 = 12;
+const PROJECT_MAX: u16 = 25;
+const NAME_MIN: u16 = 14;
+
+/// Fixed pixel widths for columns that are not PROJECT or SessionName.
+/// PROJECT and SessionName are handled separately by `project_name_constraints`.
+fn fixed_width_for(col: ColumnId) -> Constraint {
     match col {
         ColumnId::Session => Constraint::Length(10),
         ColumnId::Age => Constraint::Length(5),
@@ -577,17 +606,181 @@ fn width_for(col: ColumnId) -> Constraint {
         ColumnId::Model => Constraint::Length(20),
         ColumnId::Cpu => Constraint::Length(5),
         ColumnId::Memory => Constraint::Length(6),
-            ColumnId::DiskReadRate => Constraint::Length(8),
-            ColumnId::DiskWriteRate => Constraint::Length(8),
-            ColumnId::Tokens => Constraint::Length(8),
-            ColumnId::Context => Constraint::Length(8),
-            ColumnId::Cost => Constraint::Length(7),
-            // Cap project and session-name so they don't stretch infinitely on
-            // wide terminals. Min(N) ensures the column is always at least N wide.
-            ColumnId::Project => Constraint::Max(25),
-            ColumnId::SessionName => Constraint::Max(40),
+        ColumnId::DiskReadRate => Constraint::Length(8),
+        ColumnId::DiskWriteRate => Constraint::Length(8),
+        ColumnId::Tokens => Constraint::Length(8),
+        ColumnId::Context => Constraint::Length(8),
+        ColumnId::Cost => Constraint::Length(7),
+        // PROJECT and SessionName should be handled by project_name_constraints,
+        // not this function; fall back to sensible defaults if called directly.
+        ColumnId::Project => Constraint::Length(PROJECT_MIN),
+        ColumnId::SessionName => Constraint::Length(NAME_MIN),
         _ => Constraint::Length(8),
     }
+}
+
+/// Returns the fixed pixel width of a column (the value inside `Length`).
+/// Returns 0 for Project/SessionName (handled separately).
+fn fixed_col_width(col: ColumnId) -> u16 {
+    match col {
+        ColumnId::Session => 10,
+        ColumnId::Age => 5,
+        ColumnId::Action => 20,
+        ColumnId::Client => 14,
+        ColumnId::Subscription => 16,
+        ColumnId::Model => 20,
+        ColumnId::Cpu => 5,
+        ColumnId::Memory => 6,
+        ColumnId::DiskReadRate => 8,
+        ColumnId::DiskWriteRate => 8,
+        ColumnId::Tokens => 8,
+        ColumnId::Context => 8,
+        ColumnId::Cost => 7,
+        ColumnId::Project | ColumnId::SessionName => 0,
+        _ => 8,
+    }
+}
+
+/// Column spacing used by ratatui's Table widget (default = 1).
+const COLUMN_SPACING: u16 = 1;
+
+/// Compute the `(project_constraint, name_constraint)` pair given the visible
+/// columns and the available terminal width.
+///
+/// All columns other than PROJECT and NAME have fixed widths. The slack
+/// remaining after those fixed widths (including inter-column spacing) is
+/// split:
+///   - PROJECT gets `clamp(slack - NAME_MIN, PROJECT_MIN, PROJECT_MAX)`.
+///   - NAME gets all remaining slack (`Min(NAME_MIN)` so it still renders
+///     when slack is tight, but never forces an overflow).
+fn project_name_constraints(
+    columns: &[ColumnId],
+    activity_after: Option<usize>,
+    area_width: u16,
+) -> (Constraint, Constraint) {
+    // Count the number of constraint slots: state-dot + each column + optional ACTIVITY.
+    let n_slots = 1 // state-dot
+        + columns.len() as u16
+        + if activity_after.is_some() { 1 } else { 0 };
+    // Inter-column spacing consumed by the Table widget.
+    let spacing = n_slots.saturating_sub(1) * COLUMN_SPACING;
+
+    // Sum up all fixed-width columns in the current visible set.
+    let mut fixed_total: u16 = 5 + spacing; // state-dot + spacing
+    for (i, c) in columns.iter().enumerate() {
+        fixed_total += fixed_col_width(*c);
+        if Some(i) == activity_after {
+            fixed_total += 8; // ACTIVITY sparkline
+        }
+    }
+
+    let slack = area_width.saturating_sub(fixed_total);
+    // Reserve NAME_MIN for NAME first, then give the rest to PROJECT (capped).
+    let project_budget = slack.saturating_sub(NAME_MIN);
+    let project_w = project_budget.clamp(PROJECT_MIN, PROJECT_MAX);
+    // NAME gets all remaining slack after PROJECT; use Min so it renders even
+    // when the window is very tight.
+    (Constraint::Length(project_w), Constraint::Min(NAME_MIN))
+}
+
+/// Columns that are always shown (never dropped regardless of width).
+const ALWAYS_COLUMNS: &[ColumnId] = &[
+    ColumnId::Session,
+    ColumnId::Age,
+    ColumnId::Client,
+    ColumnId::Model,
+    ColumnId::Cpu,
+    ColumnId::Memory,
+    ColumnId::Cost,
+    ColumnId::Project,
+    ColumnId::SessionName,
+];
+
+/// Represents one step in the column drop priority sequence.
+#[derive(Clone, Copy)]
+enum DropStep {
+    /// Drop one or more named columns.
+    Cols(&'static [ColumnId]),
+    /// Drop the ACTIVITY sparkline slot (not a ColumnId; tracked separately).
+    Activity,
+}
+
+/// Drop priority sequence. Earlier entries are dropped first when space is
+/// tight. The ACTIVITY sparkline is dropped as a step independently from CLIENT.
+const DROP_SEQUENCE: &[DropStep] = &[
+    DropStep::Cols(&[ColumnId::DiskReadRate, ColumnId::DiskWriteRate]),
+    DropStep::Cols(&[ColumnId::Context]),
+    DropStep::Activity,
+    DropStep::Cols(&[ColumnId::Tokens]),
+    DropStep::Cols(&[ColumnId::Subscription]),
+    DropStep::Cols(&[ColumnId::Client]),
+];
+
+/// Returns the set of columns to display and whether to show the ACTIVITY
+/// sparkline, given the available terminal width.
+///
+/// PROJECT and NAME are always included (with minimum widths guaranteed by
+/// `project_name_constraints`). Optional columns and the ACTIVITY sparkline
+/// are dropped in priority order when space is insufficient.
+fn visible_columns_for_width(area_width: u16) -> (Vec<ColumnId>, bool) {
+    const ACTIVITY_W: u16 = 8;
+
+    // Full column set in display order.
+    let full: &[ColumnId] = &[
+        ColumnId::Session,
+        ColumnId::Age,
+        ColumnId::Client,
+        ColumnId::Subscription,
+        ColumnId::Model,
+        ColumnId::Cpu,
+        ColumnId::Memory,
+        ColumnId::DiskReadRate,
+        ColumnId::DiskWriteRate,
+        ColumnId::Tokens,
+        ColumnId::Context,
+        ColumnId::Cost,
+        ColumnId::Project,
+        ColumnId::SessionName,
+    ];
+
+    let mut active: std::collections::HashSet<ColumnId> = full.iter().copied().collect();
+    let mut show_activity = true;
+
+    /// Compute the minimum total width needed for the current active set.
+    fn min_total(
+        active: &std::collections::HashSet<ColumnId>,
+        show_activity: bool,
+    ) -> u16 {
+        let has_client = active.contains(&ColumnId::Client);
+        let act_slot = if has_client && show_activity { 1u16 } else { 0 };
+        let n_slots = 1u16 + active.len() as u16 + act_slot; // state-dot + cols + activity
+        let spacing = n_slots.saturating_sub(1) * COLUMN_SPACING;
+        let fixed: u16 = 5 // state-dot
+            + active.iter().map(|c| fixed_col_width(*c)).sum::<u16>()
+            + if has_client && show_activity { ACTIVITY_W } else { 0 }
+            + spacing;
+        fixed + PROJECT_MIN + NAME_MIN
+    }
+
+    for step in DROP_SEQUENCE {
+        if min_total(&active, show_activity) <= area_width {
+            break;
+        }
+        match step {
+            DropStep::Cols(group) => {
+                for c in *group {
+                    active.remove(c);
+                }
+            }
+            DropStep::Activity => {
+                show_activity = false;
+            }
+        }
+    }
+    // If still doesn't fit after all drops, render best-effort.
+
+    let cols = full.iter().copied().filter(|c| active.contains(c)).collect();
+    (cols, show_activity)
 }
 
 fn render_action_cell<'a>(row: &'a SessionRow, state: &SessionState, theme: &Theme) -> Cell<'a> {

--- a/crates/agtop-cli/src/tui/widgets/icon.rs
+++ b/crates/agtop-cli/src/tui/widgets/icon.rs
@@ -16,6 +16,7 @@ pub enum Icon {
     Procs,
     // Info drawer hero
     Folder,
+    Tag,
     // Config sections
     Palette,
     TableColumn,
@@ -52,6 +53,8 @@ impl Icon {
             (Self::Procs, false) => "",
             (Self::Folder, true) => "\u{F024B}", // nf-md-folder
             (Self::Folder, false) => "",
+            (Self::Tag, true) => "\u{F04F6}", // nf-md-tag_outline
+            (Self::Tag, false) => "\u{203A}", // ›
             (Self::Palette, true) => "\u{F03D8}", // nf-md-palette
             (Self::Palette, false) => "",
             (Self::TableColumn, true) => "\u{F1377}", // nf-md-table_column

--- a/crates/agtop-cli/tests/snapshots/config_snapshot__config_about_nf_off.snap
+++ b/crates/agtop-cli/tests/snapshots/config_snapshot__config_about_nf_off.snap
@@ -6,7 +6,7 @@ expression: buffer_to_text(&buf)
   Appearance                  │About
   Columns                     │────────────────────────────────────────
   ⟳  Refresh                  │
-  Clients                     │  Version       0.4.2
+  Clients                     │  Version       0.4.3
   Keybinds                    │  Git SHA       dev
   Data sources                │  Config file   /home/user/.config/agtop/config.toml
   ‹ About ›                   │  Repository    https://github.com/collectiveai-team/rust-agtop

--- a/crates/agtop-cli/tests/snapshots/config_snapshot__config_columns_nf_off.snap
+++ b/crates/agtop-cli/tests/snapshots/config_snapshot__config_columns_nf_off.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/agtop-cli/tests/config_snapshot.rs
-assertion_line: 21
 expression: buffer_to_text(&buf)
 ---
  / Search:
@@ -18,6 +17,7 @@ expression: buffer_to_text(&buf)
                               │  [x]  R/s
                               │  [x]  W/s
                               │  [x]  TOKENS
+                              │  [x]  CONTEXT
                               │  [x]  COST$
                               │  [x]  PROJECT
                               │  [x]  NAME
@@ -31,5 +31,4 @@ expression: buffer_to_text(&buf)
                               │  [ ]  DISK R
                               │  [ ]  DISK W
                               │  [ ]  OUT
-                              │  [ ]  CACHE
  [↑↓] navigate  [Tab] switch pane  [Enter] edit  [/] search  [Esc] back  [?] help

--- a/crates/agtop-cli/tests/snapshots/sessions_table_snapshot__sessions_table_140x12.snap
+++ b/crates/agtop-cli/tests/snapshots/sessions_table_snapshot__sessions_table_140x12.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/agtop-cli/tests/sessions_table_snapshot.rs
-assertion_line: 134
 expression: buffer_to_text(&buf)
 ---
-      SESSI AGE   CLIENT   ACTIVITY SUB            MODEL         CPU   MEM    R/s      W/s      TOKENS   COST$   PROJECT      NAME
-●     c2d4f 1m    codex    ⠀⠀⠀⠀⠀⠀⠀⠀                              —     —      -        -        0        —
-●     a3f2c 3m    claude-c ⠀⠀⠀⠀⠀⠀⠀⠀                              —     —      -        -        0        —
-●     f1e2d 8m    codex    ⠀⠀⠀⠀⠀⠀⠀⠀                              —     —      -        -        0        —
-●     b81e9 12m   claude-c ⠀⠀⠀⠀⠀⠀⠀⠀                              —     —      -        -        0        —
-●     d9e8a 18m   gemini-c ⠀⠀⠀⠀⠀⠀⠀⠀                              —     —      -        -        0        —
-      e5f4a 2h    copilot                                        —     —      -        -        0        —
+      SESSION AGE   CLIENT         ACTIVITY SUB              MODEL                CPU   MEM    R/s      W/s      TOKENS   CONTEXT  COST$
+●     c2d4f6a 1m    codex          ⠀⠀⠀⠀⠀⠀⠀⠀                                       —     —      -        -        0        —        —
+●     a3f2c1d 3m    claude-code    ⠀⠀⠀⠀⠀⠀⠀⠀                                       —     —      -        -        0        —        —
+●     f1e2d3c 8m    codex          ⠀⠀⠀⠀⠀⠀⠀⠀                                       —     —      -        -        0        —        —
+●     b81e940 12m   claude-code    ⠀⠀⠀⠀⠀⠀⠀⠀                                       —     —      -        -        0        —        —
+●     d9e8a7b 18m   gemini-cli     ⠀⠀⠀⠀⠀⠀⠀⠀                                       —     —      -        -        0        —        —
+      e5f4a3b 2h    copilot                                                       —     —      -        -        0        —        —

--- a/crates/agtop-cli/tests/snapshots/sessions_table_snapshot__sessions_table_140x12.snap
+++ b/crates/agtop-cli/tests/snapshots/sessions_table_snapshot__sessions_table_140x12.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/agtop-cli/tests/sessions_table_snapshot.rs
+assertion_line: 134
 expression: buffer_to_text(&buf)
 ---
-      SESSION AGE   CLIENT         ACTIVITY SUB              MODEL                CPU   MEM    R/s      W/s      TOKENS   CONTEXT  COST$
-●     c2d4f6a 1m    codex          ⠀⠀⠀⠀⠀⠀⠀⠀                                       —     —      -        -        0        —        —
-●     a3f2c1d 3m    claude-code    ⠀⠀⠀⠀⠀⠀⠀⠀                                       —     —      -        -        0        —        —
-●     f1e2d3c 8m    codex          ⠀⠀⠀⠀⠀⠀⠀⠀                                       —     —      -        -        0        —        —
-●     b81e940 12m   claude-code    ⠀⠀⠀⠀⠀⠀⠀⠀                                       —     —      -        -        0        —        —
-●     d9e8a7b 18m   gemini-cli     ⠀⠀⠀⠀⠀⠀⠀⠀                                       —     —      -        -        0        —        —
-      e5f4a3b 2h    copilot                                                       —     —      -        -        0        —        —
+      SESSION    AGE   CLIENT         SUB              MODEL                CPU   MEM    TOKENS   COST$   PROJECT             NAME
+●     c2d4f6a1   1m    codex                                                —     —      0        —
+●     a3f2c1de   3m    claude-code                                          —     —      0        —
+●     f1e2d3c4   8m    codex                                                —     —      0        —
+●     b81e9402   12m   claude-code                                          —     —      0        —
+●     d9e8a7b3   18m   gemini-cli                                           —     —      0        —
+      e5f4a3b2   2h    copilot                                              —     —      0        —


### PR DESCRIPTION
## Summary

- **Session list**: Priority-based column dropping on narrow terminals. `PROJECT` capped `[12, 25]` chars, `NAME` minimum 14 with no upper cap. Drop order: DiskRead+DiskWritten → Context → Activity sparkline → Tokens → Subscription → Client. PROJECT and NAME are always shown.
- **Usage quota panel**: Long mode now auto-selects 1/2/3 column layout based on width (>80 → 2 cols, >140 → 3 cols with 3+ providers).
- **Summary drawer**: Hero expanded to 5 rows (adds session title row); status expanded to 7 rows (adds Context usage and Disk I/O rows, filling previously empty space).

## Details

- `ColumnId` now derives `Hash` (needed for `HashSet` in drop logic)
- `visible_columns_for_width()` returns `(Vec<ColumnId>, show_activity)` — ACTIVITY sparkline is droppable independently from CLIENT
- Inter-column spacing (N−1 gaps of 1 char) correctly accounted in width budget
- Added `Icon::Tag` variant for session title label in summary drawer
- All 1038 workspace tests pass